### PR TITLE
fix: PM2 ecosystem cwd path (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.1] - 2026-03-22
+
+### Fixed
+- PM2 ecosystem config: `cwd` path used `zylos-pages` instead of `pages` (component install name), causing service startup failure on fresh installs
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.1.0
+version: 0.1.1
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   apps: [{
     name: 'zylos-pages',
     script: 'src/index.js',
-    cwd: path.join(os.homedir(), '.claude/skills/zylos-pages'),
+    cwd: path.join(os.homedir(), 'zylos/.claude/skills/pages'),
     env: {
       NODE_ENV: 'production'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Fix `ecosystem.config.cjs`: `cwd` was `~/.claude/skills/zylos-pages` but component installs as `pages`, causing PM2 startup failure on fresh installs
- Version bump to 0.1.1

## Test plan
- [ ] `zylos add pages` on a fresh instance starts PM2 service successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)