### PR TITLE
fix: add mtime validation to catch stale cache after editor writes

### DIFF
--- a/src/services/pageService.js
+++ b/src/services/pageService.js
@@ -1,7 +1,8 @@
 // Page service: orchestrates path resolution, cache, and rendering (P0 core)
 
+import { stat } from 'node:fs/promises';
 import { resolveSafePath } from '../security/pathGuard.js';
-import { getCachedPage, setCachedPage } from '../cache/pageCache.js';
+import { getCachedPage, setCachedPage, invalidatePage } from '../cache/pageCache.js';
 import { singleflight } from '../cache/singleflight.js';
 import { renderPage } from './renderService.js';
 import { normalizeSlug } from '../utils/slug.js';
@@ -19,10 +20,24 @@ export async function getPage(rawSlug, config) {
   const slug = normalizeSlug(rawSlug);
   const filePath = resolveSafePath(slug, config.contentDir);
 
-  // Check cache
+  // Check cache — with mtime validation as safety net.
+  // fs.watch on Linux can miss events from editors that use write-to-temp-then-rename
+  // (sed -i, vim, etc.). A single stat() call per cached request catches stale entries.
   const cached = getCachedPage(slug);
   if (cached) {
-    return { ...cached, cacheHit: true, singleflightShared: false };
+    try {
+      const st = await stat(filePath);
+      const fileMtime = st.mtimeMs;
+      if (cached.cachedAt && fileMtime > cached.cachedAt) {
+        invalidatePage(slug);
+        logger.info('cache stale (mtime)', { path: slug });
+        // Fall through to re-render
+      } else {
+        return { ...cached, cacheHit: true, singleflightShared: false };
+      }
+    } catch {
+      // File gone — fall through, will 404 during render
+    }
   }
 
   // Singleflight: only one render per slug at a time
@@ -35,11 +50,12 @@ export async function getPage(rawSlug, config) {
       renderTimeoutMs: config.security?.renderTimeoutMs ?? 5000,
       baseUrl: '/pages',
     });
-    // Store in cache
+    // Store in cache with timestamp for mtime validation
     setCachedPage(slug, {
       html: rendered.html,
       etag: rendered.etag,
       meta: rendered.meta,
+      cachedAt: Date.now(),
     });
     return rendered;
   });


### PR DESCRIPTION
## Summary

- `fs.watch` on Linux misses file changes from editors that use write-to-temp-then-rename (sed -i, vim, etc.)
- Added `stat()` mtime check on cached page access — if source file is newer than cache entry, invalidates and re-renders
- One extra `stat()` syscall per cached request (negligible overhead)

## Root Cause

`fs.watch` with `recursive: true` watches inodes. When `sed -i` edits a file, it:
1. Creates a temp file in the same directory
2. Writes new content to temp
3. Deletes the original and renames temp → original

This creates a new inode, and `fs.watch` doesn't detect the change.

## Fix

`pageService.getPage()` now compares the source file's `mtime` against `cachedAt` timestamp. If the file is newer, the cache entry is invalidated on access.

## Test plan
- [x] Direct file edit (`echo >>`) — detected by watcher + mtime check
- [x] `sed -i` edit — **was broken**, now detected by mtime check
- [x] `mv` rename write — detected by both watcher + mtime check
- [x] Performance: one `stat()` per cached request, ~0.1ms overhead

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)