### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.1.2] - 2026-03-23
+
+### Added
+- Document sharing: public share links with HMAC-signed stateless tokens
+  - Time-limited (24h/7d/30d) and permanent share options
+  - Share modal UI with create/copy/list/revoke functionality
+  - REST API: POST/DELETE/GET with CSRF protection
+  - Auth bypass narrowly scoped to GET/HEAD on document routes only
+  - Security: 16-byte tokenId, timing-safe compare, Referrer-Policy no-referrer
+  - Permanent shares disabled by default (`sharing.allowPermanent` config)
+  - Hourly cleanup of expired share records, revoked tombstones retained
+- `sharing` config section (`enabled`, `allowPermanent`)
+
+### Fixed
+- Cache not updating after `sed -i` / vim edits (write-to-temp-then-rename pattern). Added mtime validation on cache reads as safety net for `fs.watch` limitations on Linux
+- Page index crash when frontmatter `date` field is a YAML Date object instead of string. `gray-matter` auto-parses dates; now converts to ISO string before sorting
+
 ## [0.1.1] - 2026-03-22
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.1.1
+version: 0.1.2
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Version 0.1.2

### Added
- Document sharing with HMAC-signed stateless tokens (PR #2)

### Fixed
- Cache not updating after sed -i/vim edits — mtime validation (PR #4)
- Page index crash on Date object frontmatter (PR #4)

Updates: package.json, package-lock.json, SKILL.md, CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)