### PR TITLE
fix: handle Date objects in page index sort

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -69,7 +69,7 @@ async function scanPages(contentDir, subdir = '') {
           slug,
           title: data.title || inferTitleFromContent(content) || slug,
           description: data.description || '',
-          date: data.date || stats.mtime.toISOString().split('T')[0],
+          date: data.date instanceof Date ? data.date.toISOString().split('T')[0] : (data.date || stats.mtime.toISOString().split('T')[0]),
           tags: data.tags || [],
         });
       } catch {


### PR DESCRIPTION
## Summary

- gray-matter auto-parses YAML date fields into Date objects
- Index page sort called `.localeCompare()` which only works on strings → "Failed to list pages"
- Convert Date objects to ISO date strings before sorting

This fix was in PR #4 but was lost during squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)