### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.3] - 2026-03-23
+
+### Fixed
+- Page index crash when frontmatter `date` is a YAML Date object (fix was lost in v0.1.2 squash merge)
+
 ## [0.1.2] - 2026-03-23
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.1.2
+version: 0.1.3
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Hotfix release: includes the Date object sort fix that was lost in v0.1.2 squash merge (PR #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)