### PR TITLE
feat: TODO kanban board with web interaction (#10)

### DIFF
--- a/assets/todo.css
+++ b/assets/todo.css
@@ -1,0 +1,349 @@
+/* Todo Kanban Board Styles */
+/* Uses the same CSS variables as style.css for theme consistency */
+
+.todo-board {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.todo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.todo-title {
+  font-size: 1.75em;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.todo-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  border: none;
+  border-radius: 6px;
+  background: var(--color-link);
+  color: #fff;
+  cursor: pointer;
+}
+
+.todo-add-btn:hover { opacity: 0.9; }
+
+/* Columns */
+.todo-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.todo-column {
+  min-height: 120px;
+}
+
+.todo-column-title {
+  font-size: 1.1em;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--color-border);
+}
+
+.todo-count {
+  font-size: 0.8em;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  background: var(--color-code-bg);
+  padding: 2px 8px;
+  border-radius: 10px;
+  margin-left: 4px;
+}
+
+.todo-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.todo-empty {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  padding: 16px;
+  text-align: center;
+  border: 1px dashed var(--color-border);
+  border-radius: 8px;
+}
+
+/* Cards */
+.todo-card {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 14px 16px;
+  background: var(--color-bg);
+  transition: box-shadow 0.15s ease;
+}
+
+.todo-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="dark"] .todo-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.todo-card-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.todo-card-id {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+
+.todo-card-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--color-text);
+  line-height: 1.4;
+}
+
+/* Metadata */
+.todo-card-meta {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border);
+}
+
+.todo-meta-line {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.todo-meta-line strong {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.todo-meta-line a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+.todo-meta-line a:hover {
+  text-decoration: underline;
+}
+
+/* Action buttons */
+.todo-card-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border);
+}
+
+.todo-action-btn {
+  padding: 4px 10px;
+  font-size: 13px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: none;
+  color: var(--color-text-secondary);
+  transition: all 0.15s ease;
+}
+
+.todo-action-btn:hover {
+  background: var(--color-code-bg);
+  color: var(--color-text);
+}
+
+.todo-complete-btn:hover {
+  border-color: #2da44e;
+  color: #2da44e;
+  background: rgba(45, 164, 78, 0.08);
+}
+
+.todo-reopen-btn:hover {
+  border-color: var(--color-link);
+  color: var(--color-link);
+  background: rgba(9, 105, 218, 0.08);
+}
+
+.todo-delete-btn:hover {
+  border-color: #d1242f;
+  color: #d1242f;
+  background: rgba(209, 36, 47, 0.08);
+}
+
+/* Completed column cards are slightly muted */
+.todo-column-completed .todo-card {
+  opacity: 0.75;
+}
+
+.todo-column-completed .todo-card:hover {
+  opacity: 1;
+}
+
+/* Add Item Modal */
+.todo-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.todo-modal[hidden] { display: none; }
+
+.todo-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.todo-modal-content {
+  position: relative;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  width: 480px;
+  max-width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+}
+
+.todo-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.todo-modal-header h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.todo-modal-close {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.todo-modal-close:hover { color: var(--color-text); }
+
+.todo-modal-body {
+  padding: 20px;
+}
+
+.todo-modal-body label {
+  display: block;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin-bottom: 4px;
+  margin-top: 12px;
+}
+
+.todo-modal-body label:first-child {
+  margin-top: 0;
+}
+
+.todo-input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  box-sizing: border-box;
+}
+
+.todo-input:focus {
+  outline: none;
+  border-color: var(--color-link);
+}
+
+.todo-textarea {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  box-sizing: border-box;
+  resize: vertical;
+  font-family: var(--font-body);
+}
+
+.todo-textarea:focus {
+  outline: none;
+  border-color: var(--color-link);
+}
+
+.todo-submit-btn {
+  width: 100%;
+  margin-top: 16px;
+  padding: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  border: none;
+  border-radius: 6px;
+  background: var(--color-link);
+  color: #fff;
+  cursor: pointer;
+}
+
+.todo-submit-btn:hover { opacity: 0.9; }
+.todo-submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Responsive */
+@media (max-width: 768px) {
+  .todo-board {
+    padding: 16px;
+  }
+
+  .todo-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .todo-title {
+    font-size: 1.4em;
+  }
+
+  .todo-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .todo-modal-content {
+    width: 95vw;
+  }
+}

--- a/assets/todo.js
+++ b/assets/todo.js
@@ -1,0 +1,174 @@
+// Todo board frontend interactions
+// Handles: complete, reopen, delete, add item
+
+(function () {
+  'use strict';
+
+  // Don't init for share viewers
+  if (document.documentElement.dataset.viewer === 'share') return;
+
+  var board = document.querySelector('.todo-board');
+  if (!board) return;
+
+  var boardName = board.dataset.board;
+  var baseUrl = board.dataset.baseUrl;
+  var apiBase = baseUrl + '/api/todo/' + encodeURIComponent(boardName);
+
+  // --- Complete / Reopen / Delete via event delegation ---
+
+  board.addEventListener('click', function (e) {
+    var btn = e.target.closest('.todo-action-btn');
+    if (!btn) return;
+
+    var itemId = btn.dataset.id;
+    if (!itemId) return;
+
+    if (btn.classList.contains('todo-complete-btn')) {
+      patchStatus(itemId, 'completed');
+    } else if (btn.classList.contains('todo-reopen-btn')) {
+      patchStatus(itemId, 'active');
+    } else if (btn.classList.contains('todo-delete-btn')) {
+      if (confirm('Delete this item?')) {
+        deleteItem(itemId);
+      }
+    }
+  });
+
+  function patchStatus(itemId, status) {
+    fetch(apiBase + '/' + itemId, {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: status }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          location.reload();
+        } else {
+          alert(data.error || 'Failed to update item');
+        }
+      })
+      .catch(function () {
+        alert('Network error');
+      });
+  }
+
+  function deleteItem(itemId) {
+    fetch(apiBase + '/' + itemId, {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.ok) {
+          // Remove the card from DOM without full reload
+          var card = board.querySelector('.todo-card[data-id="' + itemId + '"]');
+          if (card) {
+            var column = card.closest('.todo-column');
+            card.remove();
+            // Update count
+            if (column) {
+              var cards = column.querySelectorAll('.todo-card');
+              var count = column.querySelector('.todo-count');
+              if (count) count.textContent = cards.length;
+              // Show empty state if needed
+              var cardsContainer = column.querySelector('.todo-cards');
+              if (cards.length === 0 && cardsContainer) {
+                cardsContainer.innerHTML = '<div class="todo-empty">No items</div>';
+              }
+            }
+          }
+        } else {
+          alert(data.error || 'Failed to delete item');
+        }
+      })
+      .catch(function () {
+        alert('Network error');
+      });
+  }
+
+  // --- Add Item Modal ---
+
+  var addBtn = document.querySelector('.todo-add-btn');
+  var modal = document.getElementById('todo-add-modal');
+
+  if (addBtn && modal) {
+    var backdrop = modal.querySelector('.todo-modal-backdrop');
+    var closeBtn = modal.querySelector('.todo-modal-close');
+    var submitBtn = modal.querySelector('.todo-submit-btn');
+    var titleInput = document.getElementById('todo-add-title');
+    var sourceInput = document.getElementById('todo-add-source');
+    var contentInput = document.getElementById('todo-add-content');
+    var linkInput = document.getElementById('todo-add-link');
+
+    addBtn.addEventListener('click', function () {
+      modal.hidden = false;
+      titleInput.value = '';
+      sourceInput.value = '';
+      contentInput.value = '';
+      linkInput.value = '';
+      titleInput.focus();
+    });
+
+    function closeModal() {
+      modal.hidden = true;
+    }
+
+    closeBtn.addEventListener('click', closeModal);
+    backdrop.addEventListener('click', closeModal);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !modal.hidden) closeModal();
+    });
+
+    submitBtn.addEventListener('click', function () {
+      var title = titleInput.value.trim();
+      if (!title) {
+        titleInput.focus();
+        return;
+      }
+
+      var metadata = {};
+      var source = sourceInput.value.trim();
+      var content = contentInput.value.trim();
+      var link = linkInput.value.trim();
+      if (source) metadata.source = source;
+      if (content) metadata.content = content;
+      if (link) metadata.link = link;
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Adding...';
+
+      fetch(apiBase, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: title, metadata: metadata }),
+      })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          if (data.ok) {
+            closeModal();
+            location.reload();
+          } else {
+            alert(data.error || 'Failed to add item');
+          }
+        })
+        .catch(function () {
+          alert('Network error');
+        })
+        .finally(function () {
+          submitBtn.disabled = false;
+          submitBtn.textContent = 'Add';
+        });
+    });
+
+    // Submit on Enter in title field
+    titleInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        submitBtn.click();
+      }
+    });
+  }
+})();

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ import { securityHeaders } from './security/headers.js';
 import { setupAuth } from './security/auth.js';
 import { createRateLimiter } from './security/rateLimit.js';
 import { setupShareApi } from './routes/share-api.js';
+import { setupTodoApi } from './routes/todo-api.js';
+import { todoRoute } from './routes/todo-page.js';
 import { cleanupShares } from './sharing/share-manager.js';
 import { pageRoute } from './routes/pages.js';
 import { indexRoute } from './routes/index.js';
@@ -89,6 +91,12 @@ async function main() {
   const sharingConfig = config.sharing || { enabled: true, allowPermanent: false };
   if (sharingConfig.enabled !== false) {
     setupShareApi(app, sharingConfig, '/pages');
+  }
+
+  // Todo routes (before catch-all)
+  if (config.todo?.enabled) {
+    setupTodoApi(app, config);
+    app.get('/todo/:board', todoRoute(config));
   }
 
   // Routes

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -47,6 +47,10 @@ export const DEFAULT_CONFIG = {
     enabled: true,
     allowPermanent: false,
   },
+  todo: {
+    enabled: false,
+    boards: {},
+  },
 };
 
 let config = null;

--- a/src/routes/todo-api.js
+++ b/src/routes/todo-api.js
@@ -1,0 +1,198 @@
+// Todo API route handlers
+// GET /api/todo/:board — list all items
+// POST /api/todo/:board — add new item
+// PATCH /api/todo/:board/:id — update item (status change)
+// DELETE /api/todo/:board/:id — remove item
+
+import path from 'node:path';
+import { parseTodoFile, updateItemStatus, deleteItem, addItem } from '../todos/todo-manager.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * CSRF validation via Origin/Referer headers.
+ * Same approach as share-api.js.
+ */
+function csrfCheck(req, res) {
+  const expectedHost = req.headers.host;
+
+  function extractHost(urlOrOrigin) {
+    try { return new URL(urlOrOrigin).host; } catch { return null; }
+  }
+
+  const origin = req.headers.origin;
+  const referer = req.headers.referer;
+
+  if (origin) {
+    if (extractHost(origin) !== expectedHost) {
+      res.status(403).json({ error: 'CSRF validation failed' });
+      return false;
+    }
+  } else if (referer) {
+    if (extractHost(referer) !== expectedHost) {
+      res.status(403).json({ error: 'CSRF validation failed' });
+      return false;
+    }
+  } else {
+    res.status(403).json({ error: 'CSRF validation failed: missing Origin/Referer' });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Parse JSON body from request (no body-parser dependency).
+ * Same pattern as share-api.js.
+ */
+function parseJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+      if (body.length > 4096) {
+        reject(Object.assign(new Error('Body too large'), { statusCode: 413 }));
+      }
+    });
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch {
+        reject(Object.assign(new Error('Invalid JSON'), { statusCode: 400 }));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Resolve a board name to its file path from config.
+ * @param {string} boardName
+ * @param {object} todoConfig - config.todo
+ * @returns {string|null} absolute file path or null
+ */
+function resolveBoardPath(boardName, todoConfig) {
+  if (!todoConfig?.boards || !todoConfig.boards[boardName]) return null;
+  const boardPath = todoConfig.boards[boardName];
+  // If already absolute, use as-is; otherwise resolve relative to HOME
+  if (path.isAbsolute(boardPath)) return boardPath;
+  return path.join(process.env.HOME, boardPath);
+}
+
+/**
+ * Register todo API routes on the Express app.
+ * Must be called AFTER auth middleware.
+ * @param {Express} app
+ * @param {object} config - Full config object
+ */
+export function setupTodoApi(app, config) {
+  const todoConfig = config.todo;
+
+  // GET /api/todo/:board — list all items
+  app.get('/api/todo/:board', (req, res) => {
+    const boardPath = resolveBoardPath(req.params.board, todoConfig);
+    if (!boardPath) {
+      return res.status(404).json({ error: 'Board not found' });
+    }
+
+    try {
+      const data = parseTodoFile(boardPath);
+      res.json({ ok: true, title: data.title, active: data.active, completed: data.completed });
+    } catch (err) {
+      const status = err.statusCode || 500;
+      logger.warn('todo list failed', { err: err.message, board: req.params.board });
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  // POST /api/todo/:board — add new item
+  app.post('/api/todo/:board', async (req, res) => {
+    if (!csrfCheck(req, res)) return;
+
+    if (res.locals.viewerType === 'share') {
+      return res.status(403).json({ error: 'Share viewers cannot modify todos' });
+    }
+
+    const boardPath = resolveBoardPath(req.params.board, todoConfig);
+    if (!boardPath) {
+      return res.status(404).json({ error: 'Board not found' });
+    }
+
+    try {
+      const body = await parseJsonBody(req);
+      const { title, metadata } = body;
+
+      if (!title || typeof title !== 'string' || !title.trim()) {
+        return res.status(400).json({ error: 'Missing or empty title' });
+      }
+
+      const item = addItem(boardPath, { title: title.trim(), metadata: metadata || {} });
+      res.json({ ok: true, item });
+    } catch (err) {
+      const status = err.statusCode || 500;
+      logger.warn('todo add failed', { err: err.message, board: req.params.board });
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  // PATCH /api/todo/:board/:id — update item (status change)
+  app.patch('/api/todo/:board/:id', async (req, res) => {
+    if (!csrfCheck(req, res)) return;
+
+    if (res.locals.viewerType === 'share') {
+      return res.status(403).json({ error: 'Share viewers cannot modify todos' });
+    }
+
+    const boardPath = resolveBoardPath(req.params.board, todoConfig);
+    if (!boardPath) {
+      return res.status(404).json({ error: 'Board not found' });
+    }
+
+    const itemId = parseInt(req.params.id, 10);
+    if (isNaN(itemId)) {
+      return res.status(400).json({ error: 'Invalid item ID' });
+    }
+
+    try {
+      const body = await parseJsonBody(req);
+      const { status } = body;
+
+      if (!status || !['active', 'completed'].includes(status)) {
+        return res.status(400).json({ error: 'Invalid status. Use "active" or "completed"' });
+      }
+
+      const item = updateItemStatus(boardPath, itemId, status);
+      res.json({ ok: true, item });
+    } catch (err) {
+      const statusCode = err.statusCode || 500;
+      logger.warn('todo update failed', { err: err.message, board: req.params.board, id: req.params.id });
+      res.status(statusCode).json({ error: err.message });
+    }
+  });
+
+  // DELETE /api/todo/:board/:id — remove item
+  app.delete('/api/todo/:board/:id', (req, res) => {
+    if (!csrfCheck(req, res)) return;
+
+    if (res.locals.viewerType === 'share') {
+      return res.status(403).json({ error: 'Share viewers cannot modify todos' });
+    }
+
+    const boardPath = resolveBoardPath(req.params.board, todoConfig);
+    if (!boardPath) {
+      return res.status(404).json({ error: 'Board not found' });
+    }
+
+    const itemId = parseInt(req.params.id, 10);
+    if (isNaN(itemId)) {
+      return res.status(400).json({ error: 'Invalid item ID' });
+    }
+
+    try {
+      deleteItem(boardPath, itemId);
+      res.json({ ok: true });
+    } catch (err) {
+      const statusCode = err.statusCode || 500;
+      logger.warn('todo delete failed', { err: err.message, board: req.params.board, id: req.params.id });
+      res.status(statusCode).json({ error: err.message });
+    }
+  });
+}

--- a/src/routes/todo-api.js
+++ b/src/routes/todo-api.js
@@ -9,6 +9,19 @@ import { parseTodoFile, updateItemStatus, deleteItem, addItem } from '../todos/t
 import { logger } from '../utils/logger.js';
 
 /**
+ * Sanitize todo input: strip newlines, markdown heading markers, and limit length.
+ */
+function sanitizeTodoInput(str, maxLen = 200) {
+  if (!str || typeof str !== 'string') return '';
+  return str
+    .replace(/[\r\n]+/g, ' ')    // collapse newlines to spaces
+    .replace(/^#{1,6}\s*/g, '')   // strip leading markdown heading markers
+    .replace(/\|/g, '—')         // replace pipe (used as ID delimiter in H3)
+    .trim()
+    .slice(0, maxLen);
+}
+
+/**
  * CSRF validation via Origin/Referer headers.
  * Same approach as share-api.js.
  */
@@ -124,7 +137,23 @@ export function setupTodoApi(app, config) {
         return res.status(400).json({ error: 'Missing or empty title' });
       }
 
-      const item = addItem(boardPath, { title: title.trim(), metadata: metadata || {} });
+      // Sanitize: strip newlines and markdown control chars from title
+      const sanitizedTitle = sanitizeTodoInput(title, 200);
+      if (!sanitizedTitle) {
+        return res.status(400).json({ error: 'Title is empty after sanitization' });
+      }
+
+      // Sanitize metadata values
+      const sanitizedMeta = {};
+      if (metadata && typeof metadata === 'object') {
+        for (const [k, v] of Object.entries(metadata)) {
+          if (typeof v === 'string') {
+            sanitizedMeta[sanitizeTodoInput(k, 50)] = sanitizeTodoInput(v, 500);
+          }
+        }
+      }
+
+      const item = addItem(boardPath, { title: sanitizedTitle, metadata: sanitizedMeta });
       res.json({ ok: true, item });
     } catch (err) {
       const status = err.statusCode || 500;

--- a/src/routes/todo-page.js
+++ b/src/routes/todo-page.js
@@ -1,0 +1,61 @@
+// Todo board page route handler
+// Renders the kanban board HTML for a given board name
+
+import path from 'node:path';
+import { parseTodoFile } from '../todos/todo-manager.js';
+import { todoTemplate } from '../templates/todoTemplate.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Resolve a board name to its file path from config.
+ */
+function resolveBoardPath(boardName, todoConfig) {
+  if (!todoConfig?.boards || !todoConfig.boards[boardName]) return null;
+  const boardPath = todoConfig.boards[boardName];
+  if (path.isAbsolute(boardPath)) return boardPath;
+  return path.join(process.env.HOME, boardPath);
+}
+
+/**
+ * Route handler factory for GET /todo/:board
+ * @param {object} config - Full config object
+ */
+export function todoRoute(config) {
+  return (req, res) => {
+    const boardName = req.params.board;
+    const todoConfig = config.todo;
+
+    if (!todoConfig?.boards?.[boardName]) {
+      return res.status(404).send('Board not found');
+    }
+
+    const boardPath = resolveBoardPath(boardName, todoConfig);
+    if (!boardPath) {
+      return res.status(404).send('Board not found');
+    }
+
+    try {
+      const data = parseTodoFile(boardPath);
+      const isAuthenticated = res.locals.authenticated;
+      const isShareViewer = res.locals.viewerType === 'share';
+
+      const html = todoTemplate({
+        title: data.title || boardName,
+        boardName,
+        active: data.active,
+        completed: data.completed,
+        baseUrl: '/pages',
+        isAuthenticated,
+        isShareViewer,
+      });
+
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-store');
+      res.send(html);
+    } catch (err) {
+      const status = err.statusCode || 500;
+      logger.error('todo page render failed', { err: err.message, board: boardName });
+      res.status(status).send(status === 404 ? 'Board file not found' : 'Internal Server Error');
+    }
+  };
+}

--- a/src/templates/todoTemplate.js
+++ b/src/templates/todoTemplate.js
@@ -1,0 +1,144 @@
+// HTML template for the TODO kanban board
+// Matches existing pages dark/light theme and header pattern
+
+import { escapeHtml } from '../security/sanitize.js';
+
+const ASSET_VERSION = Date.now();
+
+/**
+ * Generate the kanban board HTML page.
+ */
+export function todoTemplate({ title, boardName, active, completed, baseUrl, isAuthenticated, isShareViewer }) {
+  const activeHtml = renderColumn('Active', active, 'active', !isShareViewer);
+  const completedHtml = renderColumn('Completed', completed, 'completed', !isShareViewer);
+
+  return `<!DOCTYPE html>
+<html lang="en"${isShareViewer ? ' data-viewer="share"' : ''}>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)} - Todo Board</title>
+  <link rel="stylesheet" href="${baseUrl}/_assets/style.css?v=${ASSET_VERSION}">
+  <link rel="stylesheet" href="${baseUrl}/_assets/todo.css?v=${ASSET_VERSION}">
+  <script src="${baseUrl}/_assets/theme.js?v=${ASSET_VERSION}"></script>
+</head>
+<body>
+  <header class="page-header">
+    <div class="header-left">
+      <nav class="breadcrumb">
+        <a href="${baseUrl}/" class="auth-only">Pages</a>
+        <span class="sep auth-only">/</span>
+        <span class="current">${escapeHtml(title)}</span>
+      </nav>
+    </div>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle dark mode">
+        <span class="theme-icon"></span>
+      </button>
+      <form method="POST" action="${baseUrl}/logout" class="logout-form auth-only">
+        <button type="submit" class="logout-btn" aria-label="Sign out">Sign out</button>
+      </form>
+    </div>
+  </header>
+
+  <div class="todo-board" data-board="${escapeHtml(boardName)}" data-base-url="${escapeHtml(baseUrl)}">
+    <div class="todo-header">
+      <h1 class="todo-title">${escapeHtml(title)}</h1>
+      <button class="todo-add-btn auth-only" aria-label="Add item">+ Add Item</button>
+    </div>
+    <div class="todo-columns">
+      <div class="todo-column todo-column-active">
+        ${activeHtml}
+      </div>
+      <div class="todo-column todo-column-completed">
+        ${completedHtml}
+      </div>
+    </div>
+  </div>
+
+  <!-- Add Item Modal -->
+  <div id="todo-add-modal" class="todo-modal auth-only" hidden>
+    <div class="todo-modal-backdrop"></div>
+    <div class="todo-modal-content">
+      <div class="todo-modal-header">
+        <h3>Add Item</h3>
+        <button class="todo-modal-close" aria-label="Close">&times;</button>
+      </div>
+      <div class="todo-modal-body">
+        <label for="todo-add-title">Title</label>
+        <input type="text" id="todo-add-title" class="todo-input" placeholder="What needs to be done?" autofocus>
+        <label for="todo-add-source">Source (optional)</label>
+        <input type="text" id="todo-add-source" class="todo-input" placeholder="Where did this come from?">
+        <label for="todo-add-content">Content (optional)</label>
+        <textarea id="todo-add-content" class="todo-textarea" placeholder="Background details..." rows="3"></textarea>
+        <label for="todo-add-link">Link (optional)</label>
+        <input type="url" id="todo-add-link" class="todo-input" placeholder="https://...">
+        <button class="todo-submit-btn">Add</button>
+      </div>
+    </div>
+  </div>
+
+  <footer class="page-footer">
+    <a href="${baseUrl}/" class="auth-only">Back to index</a>
+  </footer>
+
+  <script src="${baseUrl}/_assets/todo.js?v=${ASSET_VERSION}"></script>
+</body>
+</html>`;
+}
+
+function renderColumn(label, items, columnType, canEdit) {
+  let html = `<h2 class="todo-column-title">${escapeHtml(label)} <span class="todo-count">${items.length}</span></h2>`;
+  html += '<div class="todo-cards">';
+
+  if (items.length === 0) {
+    html += '<div class="todo-empty">No items</div>';
+  }
+
+  for (const item of items) {
+    html += renderCard(item, columnType, canEdit);
+  }
+
+  html += '</div>';
+  return html;
+}
+
+function renderCard(item, columnType, canEdit) {
+  let html = `<div class="todo-card" data-id="${item.id}">`;
+  html += `<div class="todo-card-header">`;
+  html += `<span class="todo-card-id">#${item.id}</span>`;
+  html += `<span class="todo-card-title">${escapeHtml(item.title)}</span>`;
+  html += `</div>`;
+
+  // Metadata
+  const metaKeys = Object.keys(item.metadata || {});
+  if (metaKeys.length > 0) {
+    html += '<div class="todo-card-meta">';
+    for (const key of metaKeys) {
+      const value = item.metadata[key];
+      if (!value) continue;
+      if (key === 'link') {
+        html += `<div class="todo-meta-line"><strong>${escapeHtml(key)}:</strong> <a href="${escapeHtml(value)}" target="_blank" rel="noopener noreferrer">${escapeHtml(value)}</a></div>`;
+      } else {
+        html += `<div class="todo-meta-line"><strong>${escapeHtml(key)}:</strong> ${escapeHtml(value)}</div>`;
+      }
+    }
+    html += '</div>';
+  }
+
+  // Action buttons
+  if (canEdit) {
+    html += '<div class="todo-card-actions auth-only">';
+    if (columnType === 'active') {
+      html += `<button class="todo-action-btn todo-complete-btn" data-id="${item.id}" title="Mark completed">&#10003;</button>`;
+      html += `<button class="todo-action-btn todo-delete-btn" data-id="${item.id}" title="Delete">&#10005;</button>`;
+    } else {
+      html += `<button class="todo-action-btn todo-reopen-btn" data-id="${item.id}" title="Reopen">&#8634;</button>`;
+      html += `<button class="todo-action-btn todo-delete-btn" data-id="${item.id}" title="Delete">&#10005;</button>`;
+    }
+    html += '</div>';
+  }
+
+  html += '</div>';
+  return html;
+}

--- a/src/templates/todoTemplate.js
+++ b/src/templates/todoTemplate.js
@@ -3,6 +3,13 @@
 
 import { escapeHtml } from '../security/sanitize.js';
 
+const SAFE_URL_SCHEMES = /^https?:\/\//i;
+
+function isSafeUrl(url) {
+  if (!url || typeof url !== 'string') return false;
+  return SAFE_URL_SCHEMES.test(url.trim());
+}
+
 const ASSET_VERSION = Date.now();
 
 /**
@@ -118,7 +125,12 @@ function renderCard(item, columnType, canEdit) {
       const value = item.metadata[key];
       if (!value) continue;
       if (key === 'link') {
-        html += `<div class="todo-meta-line"><strong>${escapeHtml(key)}:</strong> <a href="${escapeHtml(value)}" target="_blank" rel="noopener noreferrer">${escapeHtml(value)}</a></div>`;
+        const safeUrl = isSafeUrl(value) ? escapeHtml(value) : null;
+        if (safeUrl) {
+          html += `<div class="todo-meta-line"><strong>${escapeHtml(key)}:</strong> <a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(value)}</a></div>`;
+        } else {
+          html += `<div class="todo-meta-line"><strong>${escapeHtml(key)}:</strong> ${escapeHtml(value)}</div>`;
+        }
       } else {
         html += `<div class="todo-meta-line"><strong>${escapeHtml(key)}:</strong> ${escapeHtml(value)}</div>`;
       }

--- a/src/todos/todo-manager.js
+++ b/src/todos/todo-manager.js
@@ -235,11 +235,23 @@ function writeTodoFile(filePath, data) {
 /**
  * Render a single todo item as markdown.
  */
+/**
+ * Strip newlines and markdown control characters from a string.
+ * Defense-in-depth: prevents structure injection even if API layer misses it.
+ */
+function sanitizeLine(str) {
+  if (!str || typeof str !== 'string') return '';
+  return str.replace(/[\r\n]+/g, ' ').replace(/^#{1,6}\s*/g, '').trim();
+}
+
 function renderItem(item) {
-  let block = `### ${item.id} | ${item.title}\n`;
+  const safeTitle = sanitizeLine(String(item.title));
+  let block = `### ${item.id} | ${safeTitle}\n`;
   for (const [key, value] of Object.entries(item.metadata)) {
     if (value !== undefined && value !== null && value !== '') {
-      block += `- **${key}**: ${value}\n`;
+      const safeKey = sanitizeLine(String(key));
+      const safeValue = sanitizeLine(String(value));
+      block += `- **${safeKey}**: ${safeValue}\n`;
     }
   }
   block += '\n';

--- a/src/todos/todo-manager.js
+++ b/src/todos/todo-manager.js
@@ -1,0 +1,247 @@
+// Todo file parser and manager
+// Reads/writes todo.md files with Active/Completed sections
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { logger } from '../utils/logger.js';
+
+let writeLock = false;
+
+/**
+ * Parse a todo.md file into structured data.
+ * @param {string} filePath - Absolute path to the .md file
+ * @returns {{ title: string, active: Array, completed: Array }}
+ */
+export function parseTodoFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw Object.assign(new Error('Todo file not found'), { statusCode: 404 });
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+
+  let title = '';
+  let currentSection = null; // 'active' | 'completed' | null
+  const active = [];
+  const completed = [];
+  let currentBlock = [];
+  let inItem = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // H1 — file title (first one only)
+    if (/^# /.test(line) && !title) {
+      title = line.replace(/^# /, '').trim();
+      continue;
+    }
+
+    // H2 — section header
+    if (/^## /i.test(line)) {
+      // Flush current item
+      if (inItem && currentBlock.length > 0) {
+        const item = parseTodoItem(currentBlock);
+        if (item && currentSection === 'active') active.push(item);
+        else if (item && currentSection === 'completed') completed.push(item);
+      }
+      currentBlock = [];
+      inItem = false;
+
+      const sectionName = line.replace(/^## /, '').trim().toLowerCase();
+      if (sectionName === 'active') currentSection = 'active';
+      else if (sectionName === 'completed') currentSection = 'completed';
+      else currentSection = null;
+      continue;
+    }
+
+    // H3 — item header
+    if (/^### /.test(line) && currentSection) {
+      // Flush previous item
+      if (inItem && currentBlock.length > 0) {
+        const item = parseTodoItem(currentBlock);
+        if (item && currentSection === 'active') active.push(item);
+        else if (item && currentSection === 'completed') completed.push(item);
+      }
+      currentBlock = [line];
+      inItem = true;
+      continue;
+    }
+
+    // Accumulate lines for current item
+    if (inItem) {
+      currentBlock.push(line);
+    }
+  }
+
+  // Flush last item
+  if (inItem && currentBlock.length > 0) {
+    const item = parseTodoItem(currentBlock);
+    if (item && currentSection === 'active') active.push(item);
+    else if (item && currentSection === 'completed') completed.push(item);
+  }
+
+  return { title, active, completed };
+}
+
+/**
+ * Parse a single H3 block into a todo item.
+ * @param {string[]} blockLines - Lines starting with the H3 header
+ * @returns {{ id: number, title: string, metadata: object } | null}
+ */
+export function parseTodoItem(blockLines) {
+  if (!blockLines || blockLines.length === 0) return null;
+
+  const headerLine = blockLines[0];
+  // Format: ### <id> | <title>
+  const headerMatch = headerLine.match(/^###\s+(\d+)\s*\|\s*(.+)/);
+  if (!headerMatch) return null;
+
+  const id = parseInt(headerMatch[1], 10);
+  const title = headerMatch[2].trim();
+
+  const metadata = {};
+
+  for (let i = 1; i < blockLines.length; i++) {
+    const line = blockLines[i].trim();
+    // Format: - **key**: value
+    const metaMatch = line.match(/^-\s+\*\*(\w+)\*\*:\s*(.*)$/);
+    if (metaMatch) {
+      metadata[metaMatch[1].toLowerCase()] = metaMatch[2].trim();
+    }
+  }
+
+  return { id, title, metadata };
+}
+
+/**
+ * Get the next available ID from a list of items.
+ * @param {Array} items - All items (active + completed)
+ * @returns {number}
+ */
+export function getNextId(items) {
+  if (!items || items.length === 0) return 1;
+  const maxId = Math.max(...items.map(i => i.id));
+  return maxId + 1;
+}
+
+/**
+ * Update an item's status (move between Active/Completed).
+ * @param {string} filePath - Path to todo.md
+ * @param {number} itemId - The item ID to move
+ * @param {string} newStatus - 'active' or 'completed'
+ */
+export function updateItemStatus(filePath, itemId, newStatus) {
+  const data = parseTodoFile(filePath);
+  const allItems = [...data.active, ...data.completed];
+  const item = allItems.find(i => i.id === itemId);
+
+  if (!item) {
+    throw Object.assign(new Error('Item not found'), { statusCode: 404 });
+  }
+
+  // Remove from current section
+  data.active = data.active.filter(i => i.id !== itemId);
+  data.completed = data.completed.filter(i => i.id !== itemId);
+
+  // Add completion date or remove it
+  if (newStatus === 'completed') {
+    item.metadata.completed = new Date().toISOString().split('T')[0];
+    data.completed.unshift(item);
+  } else {
+    delete item.metadata.completed;
+    data.active.push(item);
+  }
+
+  writeTodoFile(filePath, data);
+  logger.info('todo status updated', { filePath, itemId, newStatus });
+  return item;
+}
+
+/**
+ * Delete an item from the todo file.
+ * @param {string} filePath - Path to todo.md
+ * @param {number} itemId - The item ID to remove
+ */
+export function deleteItem(filePath, itemId) {
+  const data = parseTodoFile(filePath);
+  const activeLen = data.active.length;
+  const completedLen = data.completed.length;
+
+  data.active = data.active.filter(i => i.id !== itemId);
+  data.completed = data.completed.filter(i => i.id !== itemId);
+
+  if (data.active.length === activeLen && data.completed.length === completedLen) {
+    throw Object.assign(new Error('Item not found'), { statusCode: 404 });
+  }
+
+  writeTodoFile(filePath, data);
+  logger.info('todo item deleted', { filePath, itemId });
+}
+
+/**
+ * Add a new item to the Active section.
+ * @param {string} filePath - Path to todo.md
+ * @param {{ title: string, metadata?: object }} itemData
+ * @returns {{ id: number, title: string, metadata: object }}
+ */
+export function addItem(filePath, itemData) {
+  const data = parseTodoFile(filePath);
+  const allItems = [...data.active, ...data.completed];
+  const id = getNextId(allItems);
+
+  const metadata = {
+    ...itemData.metadata,
+    added: new Date().toISOString().split('T')[0],
+  };
+
+  const newItem = { id, title: itemData.title, metadata };
+  data.active.push(newItem);
+
+  writeTodoFile(filePath, data);
+  logger.info('todo item added', { filePath, id, title: itemData.title });
+  return newItem;
+}
+
+/**
+ * Write structured todo data back to a .md file.
+ * Uses a write lock and atomic rename pattern (like share-manager.js).
+ */
+function writeTodoFile(filePath, data) {
+  if (writeLock) {
+    throw Object.assign(new Error('Write conflict, try again'), { statusCode: 409 });
+  }
+  writeLock = true;
+  try {
+    let content = `# ${data.title || 'Todo'}\n\n`;
+
+    content += '## Active\n\n';
+    for (const item of data.active) {
+      content += renderItem(item);
+    }
+
+    content += '## Completed\n\n';
+    for (const item of data.completed) {
+      content += renderItem(item);
+    }
+
+    const tmp = filePath + '.tmp.' + process.pid;
+    fs.writeFileSync(tmp, content, 'utf-8');
+    fs.renameSync(tmp, filePath);
+  } finally {
+    writeLock = false;
+  }
+}
+
+/**
+ * Render a single todo item as markdown.
+ */
+function renderItem(item) {
+  let block = `### ${item.id} | ${item.title}\n`;
+  for (const [key, value] of Object.entries(item.metadata)) {
+    if (value !== undefined && value !== null && value !== '') {
+      block += `- **${key}**: ${value}\n`;
+    }
+  }
+  block += '\n';
+  return block;
+}


### PR DESCRIPTION
## Summary

- Add kanban-style TODO board that renders `todo.md` files as a two-column (Active/Completed) card UI with complete/reopen/delete/add interactions
- REST API at `/api/todo/:board` with full CSRF validation and session auth, following the same patterns as the existing share API
- Responsive dark/light themed UI matching the existing pages design, with modal for adding new items

## New Files

| File | Purpose |
|------|---------|
| `src/todos/todo-manager.js` | Parse and modify todo.md files (read/write with atomic rename + write lock) |
| `src/routes/todo-api.js` | REST API endpoints (GET/POST/PATCH/DELETE) |
| `src/routes/todo-page.js` | Page route that renders the kanban board HTML |
| `src/templates/todoTemplate.js` | HTML template reusing pages header, theme toggle, and CSS variables |
| `assets/todo.js` | Frontend JS for card interactions via fetch() |
| `assets/todo.css` | Kanban board styles with responsive and dark mode support |

## Modified Files

- `src/index.js` — Register todo API + page routes before the catch-all `/:slug(*)` route
- `src/lib/config.js` — Add `todo: { enabled: false, boards: {} }` to DEFAULT_CONFIG

## Configuration

Enable in `config.json`:
```json
{
  "todo": {
    "enabled": true,
    "boards": {
      "my-board": "/absolute/path/to/todo.md"
    }
  }
}
```

Then visit `/pages/todo/my-board` to see the board.

## Test plan

- [ ] Enable todo in config with a sample `todo.md` file and verify board renders at `/todo/:board`
- [ ] Test adding items via the "Add Item" button and modal
- [ ] Test completing items (moves from Active to Completed with date)
- [ ] Test reopening completed items (moves back to Active)
- [ ] Test deleting items from both columns
- [ ] Verify share viewers cannot perform write operations (403)
- [ ] Verify CSRF protection rejects cross-origin requests
- [ ] Test responsive layout on mobile viewport
- [ ] Test dark/light theme toggle on the board page

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)