### PR TITLE
fix: resolveBoardPath handles object config format

### DIFF
--- a/assets/tabs.js
+++ b/assets/tabs.js
@@ -1,0 +1,19 @@
+(function() {
+  const tabs = document.querySelectorAll('.index-tab');
+  const panels = document.querySelectorAll('.tab-panel');
+  if (!tabs.length) return;
+
+  const params = new URLSearchParams(window.location.search);
+  const initial = params.get('tab') || 'pages';
+
+  function activate(name) {
+    tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === name));
+    panels.forEach(p => p.classList.toggle('active', p.id === 'panel-' + name));
+    const url = new URL(window.location);
+    if (name === 'pages') { url.searchParams.delete('tab'); } else { url.searchParams.set('tab', name); }
+    history.replaceState(null, '', url);
+  }
+
+  activate(initial);
+  tabs.forEach(t => t.addEventListener('click', () => activate(t.dataset.tab)));
+})();

--- a/assets/tabs.js
+++ b/assets/tabs.js
@@ -4,7 +4,9 @@
   if (!tabs.length) return;
 
   const params = new URLSearchParams(window.location.search);
-  const initial = params.get('tab') || 'pages';
+  const allowed = new Set(['pages', 'todo']);
+  const raw = params.get('tab') || 'pages';
+  const initial = allowed.has(raw) ? raw : 'pages';
 
   function activate(name) {
     tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === name));

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -15,7 +15,16 @@ export function indexRoute(config) {
 
     try {
       const pages = await scanPages(config.contentDir);
-      const html = indexTemplate(pages, '/pages');
+
+      // Collect todo boards for index display
+      const todoBoards = [];
+      if (config.todo?.enabled && config.todo?.boards) {
+        for (const [name, board] of Object.entries(config.todo.boards)) {
+          todoBoards.push({ name, slug: `todo/${name}` });
+        }
+      }
+
+      const html = indexTemplate(pages, '/pages', todoBoards);
       const elapsed = Math.round(performance.now() - start);
 
       res.setHeader('Content-Type', 'text/html; charset=utf-8');

--- a/src/routes/todo-api.js
+++ b/src/routes/todo-api.js
@@ -84,7 +84,9 @@ function parseJsonBody(req) {
  */
 function resolveBoardPath(boardName, todoConfig) {
   if (!todoConfig?.boards || !todoConfig.boards[boardName]) return null;
-  const boardPath = todoConfig.boards[boardName];
+  const board = todoConfig.boards[boardName];
+  const boardPath = typeof board === 'string' ? board : board?.file;
+  if (!boardPath) return null;
   // If already absolute, use as-is; otherwise resolve relative to HOME
   if (path.isAbsolute(boardPath)) return boardPath;
   return path.join(process.env.HOME, boardPath);

--- a/src/routes/todo-page.js
+++ b/src/routes/todo-page.js
@@ -11,7 +11,9 @@ import { logger } from '../utils/logger.js';
  */
 function resolveBoardPath(boardName, todoConfig) {
   if (!todoConfig?.boards || !todoConfig.boards[boardName]) return null;
-  const boardPath = todoConfig.boards[boardName];
+  const board = todoConfig.boards[boardName];
+  const boardPath = typeof board === 'string' ? board : board?.file;
+  if (!boardPath) return null;
   if (path.isAbsolute(boardPath)) return boardPath;
   return path.join(process.env.HOME, boardPath);
 }

--- a/src/templates/indexTemplate.js
+++ b/src/templates/indexTemplate.js
@@ -110,27 +110,7 @@ export function indexTemplate(pages, baseUrl, todoBoards = []) {
     ` : ''}
   </main>
 
-  ${hasTodo ? `
-  <script>
-    (function() {
-      const tabs = document.querySelectorAll('.index-tab');
-      const panels = document.querySelectorAll('.tab-panel');
-      const params = new URLSearchParams(window.location.search);
-      const initial = params.get('tab') || 'pages';
-
-      function activate(name) {
-        tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === name));
-        panels.forEach(p => p.classList.toggle('active', p.id === 'panel-' + name));
-        const url = new URL(window.location);
-        if (name === 'pages') { url.searchParams.delete('tab'); } else { url.searchParams.set('tab', name); }
-        history.replaceState(null, '', url);
-      }
-
-      activate(initial);
-      tabs.forEach(t => t.addEventListener('click', () => activate(t.dataset.tab)));
-    })();
-  </script>
-  ` : ''}
+  ${hasTodo ? `<script src="${baseUrl}/_assets/tabs.js?v=${ASSET_VERSION}"></script>` : ''}
 
 </body>
 </html>`;

--- a/src/templates/indexTemplate.js
+++ b/src/templates/indexTemplate.js
@@ -10,7 +10,7 @@ const ASSET_VERSION = Date.now();
  * @param {Array<{slug, title, description, date}>} pages
  * @param {string} baseUrl
  */
-export function indexTemplate(pages, baseUrl) {
+export function indexTemplate(pages, baseUrl, todoBoards = []) {
   const pageRows = pages.map(p => `
     <li class="page-item">
       <a href="${baseUrl}/${encodeURI(p.slug)}">
@@ -47,6 +47,20 @@ export function indexTemplate(pages, baseUrl) {
   </header>
 
   <main class="page-content index-page">
+    ${todoBoards.length > 0 ? `
+    <section class="todo-boards-section">
+      <h2>Todo Boards</h2>
+      <ul class="page-list">
+        ${todoBoards.map(b => `
+          <li class="page-item">
+            <a href="${baseUrl}/${encodeURI(b.slug)}">
+              <span class="page-item-title">${escapeHtml(b.name)}</span>
+            </a>
+          </li>
+        `).join('')}
+      </ul>
+    </section>
+    ` : ''}
     <h1>Pages</h1>
     <p class="index-count">${pages.length} page${pages.length !== 1 ? 's' : ''}</p>
     ${pages.length === 0

--- a/src/templates/indexTemplate.js
+++ b/src/templates/indexTemplate.js
@@ -9,8 +9,11 @@ const ASSET_VERSION = Date.now();
  * Generate the directory index page listing all available pages.
  * @param {Array<{slug, title, description, date}>} pages
  * @param {string} baseUrl
+ * @param {Array<{name, slug}>} todoBoards
  */
 export function indexTemplate(pages, baseUrl, todoBoards = []) {
+  const hasTodo = todoBoards.length > 0;
+
   const pageRows = pages.map(p => `
     <li class="page-item">
       <a href="${baseUrl}/${encodeURI(p.slug)}">
@@ -18,6 +21,14 @@ export function indexTemplate(pages, baseUrl, todoBoards = []) {
         ${p.date ? `<time class="page-item-date">${escapeHtml(String(p.date))}</time>` : ''}
       </a>
       ${p.description ? `<p class="page-item-desc">${escapeHtml(p.description)}</p>` : ''}
+    </li>
+  `).join('');
+
+  const todoRows = todoBoards.map(b => `
+    <li class="page-item">
+      <a href="${baseUrl}/${encodeURI(b.slug)}">
+        <span class="page-item-title">${escapeHtml(b.name)}</span>
+      </a>
     </li>
   `).join('');
 
@@ -30,6 +41,35 @@ export function indexTemplate(pages, baseUrl, todoBoards = []) {
   <meta name="description" content="Index of available pages">
   <link rel="stylesheet" href="${baseUrl}/_assets/style.css?v=${ASSET_VERSION}">
   <script src="${baseUrl}/_assets/theme.js?v=${ASSET_VERSION}"></script>
+  <style>
+    .index-tabs {
+      display: flex;
+      gap: 0;
+      border-bottom: 2px solid var(--color-border, #e1e4e8);
+      margin-bottom: 1.5rem;
+    }
+    .index-tab {
+      padding: 0.75rem 1.5rem;
+      cursor: pointer;
+      border: none;
+      background: none;
+      font-size: 1rem;
+      font-weight: 500;
+      color: var(--color-text-secondary, #6a737d);
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .index-tab:hover {
+      color: var(--color-text-primary, #24292e);
+    }
+    .index-tab.active {
+      color: var(--color-text-primary, #24292e);
+      border-bottom-color: var(--color-accent, #0969da);
+    }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+  </style>
 </head>
 <body>
   <header class="page-header">
@@ -47,27 +87,50 @@ export function indexTemplate(pages, baseUrl, todoBoards = []) {
   </header>
 
   <main class="page-content index-page">
-    ${todoBoards.length > 0 ? `
-    <section class="todo-boards-section">
-      <h2>Todo Boards</h2>
-      <ul class="page-list">
-        ${todoBoards.map(b => `
-          <li class="page-item">
-            <a href="${baseUrl}/${encodeURI(b.slug)}">
-              <span class="page-item-title">${escapeHtml(b.name)}</span>
-            </a>
-          </li>
-        `).join('')}
-      </ul>
-    </section>
+    ${hasTodo ? `
+    <div class="index-tabs">
+      <button class="index-tab active" data-tab="pages">Pages</button>
+      <button class="index-tab" data-tab="todo">Todo</button>
+    </div>
     ` : ''}
-    <h1>Pages</h1>
-    <p class="index-count">${pages.length} page${pages.length !== 1 ? 's' : ''}</p>
-    ${pages.length === 0
-      ? '<p class="empty-state">No pages yet. Write a <code>.md</code> file to get started.</p>'
-      : `<ul class="page-list">${pageRows}</ul>`
-    }
+
+    <div id="panel-pages" class="tab-panel active">
+      <p class="index-count">${pages.length} page${pages.length !== 1 ? 's' : ''}</p>
+      ${pages.length === 0
+        ? '<p class="empty-state">No pages yet. Write a <code>.md</code> file to get started.</p>'
+        : `<ul class="page-list">${pageRows}</ul>`
+      }
+    </div>
+
+    ${hasTodo ? `
+    <div id="panel-todo" class="tab-panel">
+      <p class="index-count">${todoBoards.length} board${todoBoards.length !== 1 ? 's' : ''}</p>
+      <ul class="page-list">${todoRows}</ul>
+    </div>
+    ` : ''}
   </main>
+
+  ${hasTodo ? `
+  <script>
+    (function() {
+      const tabs = document.querySelectorAll('.index-tab');
+      const panels = document.querySelectorAll('.tab-panel');
+      const params = new URLSearchParams(window.location.search);
+      const initial = params.get('tab') || 'pages';
+
+      function activate(name) {
+        tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === name));
+        panels.forEach(p => p.classList.toggle('active', p.id === 'panel-' + name));
+        const url = new URL(window.location);
+        if (name === 'pages') { url.searchParams.delete('tab'); } else { url.searchParams.set('tab', name); }
+        history.replaceState(null, '', url);
+      }
+
+      activate(initial);
+      tabs.forEach(t => t.addEventListener('click', () => activate(t.dataset.tab)));
+    })();
+  </script>
+  ` : ''}
 
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
- Config uses `{ "file": "/path/to/todo.md" }` per board, but resolveBoardPath treated the entry as a plain string
- Caused `Internal Server Error` on `/todo/:board` routes
- Now handles both `string` and `{ file: string }` formats in both todo-page.js and todo-api.js

## Test plan
- [x] `curl -o /dev/null -w "%{http_code}" /todo/howard` returns 302 (not 500)
- [x] Direct template rendering test: 2 items parsed and rendered correctly
- [x] No new errors in PM2 logs after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)