### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.5] - 2026-04-07
+
+### Added
+- TODO kanban board: interactive web-based task management with drag-and-drop columns
+- Tab-based navigation on index page (Pages / Todo tabs) with URL state sync
+- Security: `isSafeUrl()` link validation and `sanitizeTodoInput()`/`sanitizeLine()` to prevent XSS and markdown structure injection (code review by Jinglever)
+
+### Fixed
+- `resolveBoardPath` now handles object config format (`board.file`)
+- Tab switching JS moved to external `tabs.js` for CSP `script-src 'self'` compliance (inline script was silently blocked)
+- Invalid `tab` query parameter (e.g. `?tab=foo`) no longer causes blank page — falls back to `pages`
+
 ## [0.1.4] - 2026-03-23
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.1.4
+version: 0.1.5
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Version bump to 0.1.5
- Updated CHANGELOG with all changes since 0.1.4 (TODO kanban, tab UI, CSP fix, board path fix, security hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)