### PR TITLE
fix: sync package-lock.json version to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
- package-lock.json was missed during the v0.1.5 version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)