### PR TITLE
feat: copy raw Markdown from page header

### DIFF
--- a/assets/raw.js
+++ b/assets/raw.js
@@ -1,0 +1,76 @@
+// Copy raw Markdown frontend logic
+
+(function () {
+  'use strict';
+
+  if (document.documentElement.dataset.viewer === 'share') return;
+
+  var copyBtn = document.querySelector('.copy-raw-btn');
+  if (!copyBtn) return;
+
+  var defaultText = copyBtn.textContent.trim() || 'Copy Markdown';
+  var slug = copyBtn.dataset.slug || '';
+  var baseUrl = copyBtn.dataset.baseUrl || '';
+  var label = copyBtn.querySelector('.copy-raw-label');
+
+  function setButtonText(text) {
+    copyBtn.setAttribute('aria-label', text === defaultText ? 'Copy raw Markdown' : text);
+    if (label) {
+      label.textContent = text;
+      return;
+    }
+    copyBtn.appendChild(document.createTextNode(' ' + text));
+  }
+
+  function copyText(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    return new Promise(function (resolve, reject) {
+      var textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.top = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+
+      try {
+        var copied = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        copied ? resolve() : reject(new Error('copy failed'));
+      } catch (err) {
+        document.body.removeChild(textarea);
+        reject(err);
+      }
+    });
+  }
+
+  function resetButton() {
+    copyBtn.disabled = false;
+    setButtonText(defaultText);
+  }
+
+  copyBtn.addEventListener('click', function () {
+    copyBtn.disabled = true;
+    setButtonText('Copying...');
+
+    fetch(baseUrl + '/api/raw/' + encodeURIComponent(slug), {
+      headers: { Accept: 'text/plain' },
+    })
+      .then(function (res) {
+        if (!res.ok) throw new Error('raw fetch failed');
+        return res.text();
+      })
+      .then(copyText)
+      .then(function () {
+        setButtonText('Copied');
+        setTimeout(resetButton, 2000);
+      })
+      .catch(function () {
+        setButtonText('Failed');
+        setTimeout(resetButton, 2000);
+      });
+  });
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -559,8 +559,9 @@ body {
 /* Share viewer — hide auth-only elements */
 [data-viewer="share"] .auth-only { display: none !important; }
 
-/* Share button */
-.share-btn {
+/* Header action buttons */
+.share-btn,
+.copy-raw-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -573,9 +574,28 @@ body {
   font-size: 13px;
 }
 
-.share-btn:hover { background: var(--color-code-bg); color: var(--color-link); }
+.share-btn:hover,
+.copy-raw-btn:hover { background: var(--color-code-bg); color: var(--color-link); }
 
-.share-btn svg { flex-shrink: 0; }
+.share-btn:disabled,
+.copy-raw-btn:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.share-btn svg,
+.copy-raw-btn svg { flex-shrink: 0; }
+
+@media (max-width: 768px) {
+  .copy-raw-btn {
+    min-width: 44px;
+    min-height: 44px;
+    justify-content: center;
+    padding: 4px 8px;
+  }
+
+  .copy-raw-label { display: none; }
+}
 
 /* Share Modal */
 .share-modal {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { securityHeaders } from './security/headers.js';
 import { setupAuth } from './security/auth.js';
 import { createRateLimiter } from './security/rateLimit.js';
 import { setupShareApi } from './routes/share-api.js';
+import { setupRawApi } from './routes/raw-api.js';
 import { setupTodoApi } from './routes/todo-api.js';
 import { todoRoute } from './routes/todo-page.js';
 import { cleanupShares } from './sharing/share-manager.js';
@@ -92,6 +93,7 @@ async function main() {
   if (sharingConfig.enabled !== false) {
     setupShareApi(app, sharingConfig, '/pages');
   }
+  setupRawApi(app, config);
 
   // Todo routes (before catch-all)
   if (config.todo?.enabled) {

--- a/src/routes/raw-api.js
+++ b/src/routes/raw-api.js
@@ -1,0 +1,49 @@
+// Raw Markdown API route handlers
+// GET /api/raw/:slug(*) - return the original Markdown text (requires login)
+
+import { readFile } from 'node:fs/promises';
+import { resolveSafePath } from '../security/pathGuard.js';
+import { normalizeSlug } from '../utils/slug.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Register raw Markdown API routes on the Express app.
+ * Must be called AFTER auth middleware so that only authenticated users reach these.
+ * @param {Express} app
+ * @param {object} config - full app config
+ */
+export function setupRawApi(app, config) {
+  app.get('/api/raw/:slug(*)', async (req, res) => {
+    if (res.locals.viewerType === 'share') {
+      return res.status(403).json({ error: 'Share viewers cannot read raw Markdown' });
+    }
+
+    const rawSlug = req.params.slug || req.params[0] || '';
+    let slug;
+    let filePath;
+
+    try {
+      slug = normalizeSlug(rawSlug);
+      filePath = resolveSafePath(slug, config.contentDir);
+    } catch (err) {
+      const status = err.statusCode || 400;
+      logger.warn('raw markdown path rejected', { path: rawSlug, status, err: err.message });
+      return res.status(status).json({ error: 'Invalid path' });
+    }
+
+    try {
+      const markdown = await readFile(filePath, 'utf8');
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      return res.status(200).send(markdown);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        logger.info('raw markdown not found', { path: slug });
+        return res.status(404).json({ error: 'Page not found' });
+      }
+
+      logger.error('raw markdown read failed', { path: slug, err: err.message });
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  });
+}

--- a/src/templates/pageTemplate.js
+++ b/src/templates/pageTemplate.js
@@ -29,6 +29,7 @@ export function pageTemplate({ title, description, date, tags, bodyHtml, tocItem
   <link rel="stylesheet" href="${baseUrl}/_assets/style.css?v=${ASSET_VERSION}">
   <link rel="stylesheet" href="${baseUrl}/_assets/print.css?v=${ASSET_VERSION}" media="print">
   <script src="${baseUrl}/_assets/theme.js?v=${ASSET_VERSION}"></script>
+  <script src="${baseUrl}/_assets/raw.js?v=${ASSET_VERSION}" defer></script>
 </head>
 <body>
   <header class="page-header">
@@ -43,6 +44,10 @@ export function pageTemplate({ title, description, date, tags, bodyHtml, tocItem
       </nav>
     </div>
     <div class="header-actions">
+      <button class="copy-raw-btn auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Copy raw Markdown">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M5 1.5A1.5 1.5 0 0 1 6.5 0h6A1.5 1.5 0 0 1 14 1.5v8A1.5 1.5 0 0 1 12.5 11h-6A1.5 1.5 0 0 1 5 9.5zm1.5-.25a.25.25 0 0 0-.25.25v8c0 .138.112.25.25.25h6a.25.25 0 0 0 .25-.25v-8a.25.25 0 0 0-.25-.25zM2 4.5A1.5 1.5 0 0 1 3.5 3H4v1.25h-.5a.25.25 0 0 0-.25.25v8c0 .138.112.25.25.25h6a.25.25 0 0 0 .25-.25V12H11v.5A1.5 1.5 0 0 1 9.5 14h-6A1.5 1.5 0 0 1 2 12.5z"/></svg>
+        <span class="copy-raw-label">Copy Markdown</span>
+      </button>
       <button class="share-btn auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Share this page">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.5 2.5 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5z"/></svg>
         Share

--- a/test/raw-api.test.js
+++ b/test/raw-api.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import express from 'express';
+import { setupRawApi } from '../src/routes/raw-api.js';
+
+async function withServer(viewerType, fn) {
+  const contentDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-raw-'));
+  const app = express();
+
+  app.use((req, res, next) => {
+    if (viewerType) res.locals.viewerType = viewerType;
+    next();
+  });
+  setupRawApi(app, { contentDir });
+
+  const server = await new Promise((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+
+  try {
+    await fn({ baseUrl, contentDir });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve());
+    });
+    await rm(contentDir, { recursive: true, force: true });
+  }
+}
+
+test('raw API returns the original Markdown text', async () => {
+  await withServer(null, async ({ baseUrl, contentDir }) => {
+    const markdown = '---\ntitle: Raw Source\n---\n\n# Raw Source\n\nOriginal **Markdown**.\n';
+    await writeFile(path.join(contentDir, 'raw-source.md'), markdown);
+
+    const res = await fetch(`${baseUrl}/api/raw/raw-source`);
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type'), /^text\/plain; charset=utf-8/);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.equal(await res.text(), markdown);
+  });
+});
+
+test('raw API supports nested Markdown slugs', async () => {
+  await withServer(null, async ({ baseUrl, contentDir }) => {
+    await mkdir(path.join(contentDir, 'docs'), { recursive: true });
+    await writeFile(path.join(contentDir, 'docs', 'guide.md'), '# Guide\n');
+
+    const res = await fetch(`${baseUrl}/api/raw/${encodeURIComponent('docs/guide')}`);
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '# Guide\n');
+  });
+});
+
+test('raw API returns 404 for missing pages', async () => {
+  await withServer(null, async ({ baseUrl }) => {
+    const res = await fetch(`${baseUrl}/api/raw/missing`);
+    assert.equal(res.status, 404);
+    assert.deepEqual(await res.json(), { error: 'Page not found' });
+  });
+});
+
+test('raw API rejects traversal slugs', async () => {
+  await withServer(null, async ({ baseUrl }) => {
+    const res = await fetch(`${baseUrl}/api/raw/%252e%252e/secret`);
+    assert.equal(res.status, 400);
+    assert.deepEqual(await res.json(), { error: 'Invalid path' });
+  });
+});
+
+test('raw API is unavailable to share viewers', async () => {
+  await withServer('share', async ({ baseUrl, contentDir }) => {
+    await writeFile(path.join(contentDir, 'private.md'), '# Private\n');
+
+    const res = await fetch(`${baseUrl}/api/raw/private`);
+    assert.equal(res.status, 403);
+    assert.deepEqual(await res.json(), { error: 'Share viewers cannot read raw Markdown' });
+  });
+});


### PR DESCRIPTION
## Summary
- add an authenticated raw Markdown API for document slugs
- add a page header button that fetches raw Markdown and copies it to the clipboard
- keep the control hidden for share viewers and collapse the new label on mobile

## Tests
- node --test test/raw-api.test.js
- npm test
- node --check src/routes/raw-api.js && node --check assets/raw.js && node --check src/templates/pageTemplate.js && git diff --check