### PR TITLE
chore: release zylos-pages v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.8] - 2026-05-06
+
+### Added
+- **Copy raw Markdown button** (#21): Copy the original Markdown source text from the page header. Correctly hidden from share viewers.
+
+### Fixed
+- **Dynamic base-path auth routes** (#20): Removes hardcoded `/pages` base URL. All routes dynamically resolve from `X-Forwarded-Prefix` header, supporting both Caddy stripped-prefix proxy and direct local access. New `browser-base.js` module with prefix validation, open-redirect prevention, and dot-segment escape protection. Cache keys include browser base to prevent cross-prefix poisoning. 7 new tests added.
+
 ## [0.1.7] - 2026-04-27
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.1.7
+version: 0.1.8
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.8
- Update CHANGELOG, SKILL.md, package.json, package-lock.json

### Changes since v0.1.7
- **feat**: Copy raw Markdown button (#21)
- **fix**: Dynamic base-path auth routes via X-Forwarded-Prefix (#20)

27/27 tests pass.