### PR TITLE
feat: inject window.__PAGES_BASE into HTML artifacts

### DIFF
--- a/src/routes/pages.js
+++ b/src/routes/pages.js
@@ -64,7 +64,9 @@ export function pageRoute(config) {
 
       if (isHtmlArtifact) {
         logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: result.type });
-        return res.send(result.html);
+        const baseTag = `<script>window.__PAGES_BASE=${JSON.stringify(browserBase)};</script>`;
+        const injected = result.html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
+        return res.send(injected !== result.html ? injected : baseTag + result.html);
       }
 
       // For share viewers: inject data-viewer attribute to hide auth-only elements


### PR DESCRIPTION
## Summary

When serving HTML artifacts, inject `window.__PAGES_BASE` (from X-Forwarded-Prefix) into `<head>` so client-side JS can build correct API URLs regardless of reverse proxy prefix depth.

This is needed for the State API (#30/#32) — HTML artifacts need to `fetch()` the correct API path (e.g. `/pages/api/state/...` not `/api/state/...`).

## Changes

- `src/routes/pages.js`: inject `<script>window.__PAGES_BASE=...</script>` into HTML artifact `<head>` before sending response

## Test plan

- [ ] `npm test` — 68/68 pass
- [ ] HTML artifact page source shows injected `__PAGES_BASE` script tag
- [ ] `fetch(window.__PAGES_BASE + '/api/state/...')` reaches the correct endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)