### PR TITLE
fix: return short share links by default

### DIFF
--- a/docs/dev-plan-issue-42.md
+++ b/docs/dev-plan-issue-42.md
@@ -8,37 +8,37 @@ Make `/s/<tokenId>` the native share entry point. Share records move to SQLite, 
 - Out of scope: deleting the legacy `shares.json` file from disk, changing authenticated admin session storage, and removing legacy `?token=` compatibility if keeping it is low-cost and non-exposed.
 
 ## Development Checklist
-- [ ] Add `shares` and `share_sessions` tables to `pages.db`.
-- [ ] Import legacy `shares.json` records into `shares` once without continuing to write JSON.
-- [ ] Refactor share creation/list/revoke/cleanup to use SQLite.
-- [ ] Add opaque share access session creation and validation.
-- [ ] Change `/s/:tokenId` to validate the DB share, set share access/scope cookies, and redirect to clean `/<slug>`.
-- [ ] Update auth middleware so share access sessions authorize matching page/raw HTML/state API access.
-- [ ] Keep asset authorization scoped to the shared page directory and invalidated by revoke/expiry.
-- [ ] Remove generated/exposed long share URL fields from API responses.
-- [ ] Remove token propagation from HTML artifact iframe URLs.
+- [x] Add `shares` and `share_sessions` tables to `pages.db`.
+- [x] Import legacy `shares.json` records into `shares` once without continuing to write JSON.
+- [x] Refactor share creation/list/revoke/cleanup to use SQLite.
+- [x] Add opaque share access session creation and validation.
+- [x] Change `/s/:tokenId` to validate the DB share, set share access/scope cookies, and redirect to clean `/<slug>`.
+- [x] Update auth middleware so share access sessions authorize matching page/raw HTML/state API access.
+- [x] Keep asset authorization scoped to the shared page directory and invalidated by revoke/expiry.
+- [x] Remove generated/exposed long share URL fields from API responses.
+- [x] Remove token propagation from HTML artifact iframe URLs.
 
 ## Test Checklist
-- [ ] Share creation response has `url`/`shortUrl` only and no `longUrl`.
-- [ ] Valid `/s/<tokenId>` redirects to clean page URL, sets cookies, and does not expose `?token=`.
-- [ ] HTML artifact wrapper and raw iframe load through short share access.
-- [ ] State API reads and writes work through short share access while still enforcing CSRF for writes.
-- [ ] Static assets work through share scope without accepting direct `?token=` asset access.
-- [ ] Revoked, expired, missing, and malformed tokenIds fail.
-- [ ] `sharing.enabled=false` keeps unauthenticated `/s/<32hex>` behind the login wall.
-- [ ] Legacy `shares.json` records import into DB.
+- [x] Share creation response has `url`/`shortUrl` only and no `longUrl`.
+- [x] Valid `/s/<tokenId>` redirects to clean page URL, sets cookies, and does not expose `?token=`.
+- [x] HTML artifact wrapper and raw iframe load through short share access.
+- [x] State API reads and writes work through short share access while still enforcing CSRF for writes.
+- [x] Static assets work through share scope without accepting direct `?token=` asset access.
+- [x] Revoked, expired, missing, and malformed tokenIds fail.
+- [x] `sharing.enabled=false` keeps unauthenticated `/s/<32hex>` behind the login wall.
+- [x] Legacy `shares.json` records import into DB.
 
 ## Assumptions
-- [ ] `tokenId` remains a 32-character lowercase hex value; guaranteed by the existing token generator and enforced at route/auth boundaries.
-- [ ] Share lookup is server-stateful under the new product decision; guaranteed by Howard's decision to move sharing to DB.
-- [ ] SQLite is sufficient for Pages personal-document concurrency; guaranteed by product scope, not a general multi-user assumption.
-- [ ] Keeping old `?token=` verification is acceptable only as hidden legacy compatibility; it must not be returned by API/UI or required by short-link flows.
-- [ ] Share access sessions may be revoked indirectly by checking the current share record on every validation.
+- [x] `tokenId` remains a 32-character lowercase hex value; guaranteed by the existing token generator and enforced at route/auth boundaries.
+- [x] Share lookup is server-stateful under the new product decision; guaranteed by Howard's decision to move sharing to DB.
+- [x] SQLite is sufficient for Pages personal-document concurrency; guaranteed by product scope, not a general multi-user assumption.
+- [x] Keeping old `?token=` verification is acceptable only as hidden legacy compatibility; it must not be returned by API/UI or required by short-link flows.
+- [x] Share access sessions may be revoked indirectly by checking the current share record on every validation.
 
 ## Acceptance Checklist
-- [ ] Issue #42 expected behavior is met.
-- [ ] Existing Issue #40 short-link default behavior remains met.
-- [ ] No long HMAC token appears in share create responses, short-link redirects, or HTML iframe src.
-- [ ] No regression in login/session auth, raw API blocking for share viewers, and asset 403 behavior.
-- [ ] Focused tests pass.
-- [ ] Full `npm test` passes.
+- [x] Issue #42 expected behavior is met.
+- [x] Existing Issue #40 short-link default behavior remains met.
+- [x] No long HMAC token appears in share create responses, short-link redirects, or HTML iframe src.
+- [x] No regression in login/session auth, raw API blocking for share viewers, and asset 403 behavior.
+- [x] Focused tests pass.
+- [x] Full `npm test` passes.

--- a/docs/dev-plan-issue-42.md
+++ b/docs/dev-plan-issue-42.md
@@ -1,0 +1,44 @@
+# Dev Plan: Move Sharing Fully To Short-Link Native Access (#42)
+
+## Summary
+Make `/s/<tokenId>` the native share entry point. Share records move to SQLite, valid short-link visits create an opaque share access session, and public/API/UI paths stop exposing long HMAC token URLs.
+
+## Scope
+- In scope: DB-backed share records, legacy `shares.json` import, share access sessions, short-link redirects to clean page URLs, page/raw/state/static-asset access via share cookies, removal of `longUrl` from create-share responses, and tests for revoked/expired/disabled sharing behavior.
+- Out of scope: deleting the legacy `shares.json` file from disk, changing authenticated admin session storage, and removing legacy `?token=` compatibility if keeping it is low-cost and non-exposed.
+
+## Development Checklist
+- [ ] Add `shares` and `share_sessions` tables to `pages.db`.
+- [ ] Import legacy `shares.json` records into `shares` once without continuing to write JSON.
+- [ ] Refactor share creation/list/revoke/cleanup to use SQLite.
+- [ ] Add opaque share access session creation and validation.
+- [ ] Change `/s/:tokenId` to validate the DB share, set share access/scope cookies, and redirect to clean `/<slug>`.
+- [ ] Update auth middleware so share access sessions authorize matching page/raw HTML/state API access.
+- [ ] Keep asset authorization scoped to the shared page directory and invalidated by revoke/expiry.
+- [ ] Remove generated/exposed long share URL fields from API responses.
+- [ ] Remove token propagation from HTML artifact iframe URLs.
+
+## Test Checklist
+- [ ] Share creation response has `url`/`shortUrl` only and no `longUrl`.
+- [ ] Valid `/s/<tokenId>` redirects to clean page URL, sets cookies, and does not expose `?token=`.
+- [ ] HTML artifact wrapper and raw iframe load through short share access.
+- [ ] State API reads and writes work through short share access while still enforcing CSRF for writes.
+- [ ] Static assets work through share scope without accepting direct `?token=` asset access.
+- [ ] Revoked, expired, missing, and malformed tokenIds fail.
+- [ ] `sharing.enabled=false` keeps unauthenticated `/s/<32hex>` behind the login wall.
+- [ ] Legacy `shares.json` records import into DB.
+
+## Assumptions
+- [ ] `tokenId` remains a 32-character lowercase hex value; guaranteed by the existing token generator and enforced at route/auth boundaries.
+- [ ] Share lookup is server-stateful under the new product decision; guaranteed by Howard's decision to move sharing to DB.
+- [ ] SQLite is sufficient for Pages personal-document concurrency; guaranteed by product scope, not a general multi-user assumption.
+- [ ] Keeping old `?token=` verification is acceptable only as hidden legacy compatibility; it must not be returned by API/UI or required by short-link flows.
+- [ ] Share access sessions may be revoked indirectly by checking the current share record on every validation.
+
+## Acceptance Checklist
+- [ ] Issue #42 expected behavior is met.
+- [ ] Existing Issue #40 short-link default behavior remains met.
+- [ ] No long HMAC token appears in share create responses, short-link redirects, or HTML iframe src.
+- [ ] No regression in login/session auth, raw API blocking for share viewers, and asset 403 behavior.
+- [ ] Focused tests pass.
+- [ ] Full `npm test` passes.

--- a/src/index.js
+++ b/src/index.js
@@ -88,11 +88,13 @@ async function main() {
   };
   app.use('/_assets', express.static(assetsDir, staticOptions));
 
-  // Cookie-based session authentication
-  setupAuth(app, config.auth || {});
-
   // Share API routes (after auth — requires authenticated session)
   const sharingConfig = config.sharing || { enabled: true, allowPermanent: false };
+
+  // Cookie-based session authentication
+  setupAuth(app, config.auth || {}, sharingConfig);
+
+  // Share API routes (after auth — requires authenticated session)
   if (sharingConfig.enabled !== false) {
     setupShareApi(app, sharingConfig);
   }

--- a/src/routes/pages.js
+++ b/src/routes/pages.js
@@ -80,8 +80,7 @@ export function pageRoute(config) {
       if (isHtmlArtifact) {
         const titleMatch = result.html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
         const title = titleMatch ? titleMatch[1].replace(/\s+/g, ' ').trim() : slug;
-        const tokenParam = isShareViewer && req.query.token ? `&token=${encodeURIComponent(req.query.token)}` : '';
-        const iframeSrc = `${browserBase}/${encodeURI(slug)}?raw=1${tokenParam}`;
+        const iframeSrc = `${browserBase}/${encodeURI(slug)}?raw=1`;
         let html = htmlArtifactTemplate({ title, baseUrl: browserBase, slug, iframeSrc });
         if (isShareViewer) {
           html = injectShareViewer(html);

--- a/src/routes/share-api.js
+++ b/src/routes/share-api.js
@@ -4,7 +4,7 @@
 // GET /api/shares/:slug(*) — list active shares for slug (requires login)
 // DELETE /api/shares/:slug(*) — revoke all shares for slug (requires login + CSRF)
 
-import { createShare, revokeShare, revokeAllForSlug, listSharesForSlug } from '../sharing/share-manager.js';
+import { createShare, getActiveShareToken, revokeShare, revokeAllForSlug, listSharesForSlug } from '../sharing/share-manager.js';
 import { normalizeSlug } from '../utils/slug.js';
 import { logger } from '../utils/logger.js';
 import { browserBaseFromRequest, browserPath } from '../lib/browser-base.js';
@@ -64,6 +64,16 @@ function parseJsonBody(req) {
   });
 }
 
+function absoluteUrl(req, path) {
+  const proto = req.headers['x-forwarded-proto'] || 'https';
+  const host = req.headers.host;
+  return `${proto}://${host}${path}`;
+}
+
+function longSharePath(browserBase, slug, token) {
+  return `${browserPath(browserBase, slug)}?token=${encodeURIComponent(token)}`;
+}
+
 /**
  * Register share API routes on the Express app.
  * Must be called AFTER auth middleware so that only authenticated users reach these.
@@ -71,6 +81,18 @@ function parseJsonBody(req) {
  * @param {object} sharingConfig - { allowPermanent }
  */
 export function setupShareApi(app, sharingConfig) {
+  // GET /s/:tokenId — short share link redirect
+  app.get('/s/:tokenId', (req, res) => {
+    const share = getActiveShareToken(req.params.tokenId);
+    if (!share) {
+      return res.status(404).send('Share not found');
+    }
+
+    const browserBase = browserBaseFromRequest(req);
+    res.setHeader('Cache-Control', 'no-store');
+    res.redirect(302, longSharePath(browserBase, share.slug, share.token));
+  });
+
   // POST /api/share — create a share link
   app.post('/api/share', async (req, res) => {
     if (!csrfCheck(req, res)) return;
@@ -93,18 +115,18 @@ export function setupShareApi(app, sharingConfig) {
 
       const result = createShare(slug, duration, sharingConfig);
 
-      // Build the share URL
-      const proto = req.headers['x-forwarded-proto'] || 'https';
-      const host = req.headers.host;
       const normalizedSlug = normalizeSlug(slug);
       const browserBase = browserBaseFromRequest(req);
-      const shareUrl = `${proto}://${host}${browserPath(browserBase, normalizedSlug)}?token=${result.token}`;
+      const shortUrl = absoluteUrl(req, browserPath(browserBase, `s/${result.tokenId}`));
+      const longUrl = absoluteUrl(req, longSharePath(browserBase, normalizedSlug, result.token));
 
       res.json({
         ok: true,
         tokenId: result.tokenId,
         expiresAt: result.expiresAt,
-        url: shareUrl,
+        url: shortUrl,
+        shortUrl,
+        longUrl,
       });
     } catch (err) {
       const status = err.statusCode || 500;

--- a/src/routes/share-api.js
+++ b/src/routes/share-api.js
@@ -4,8 +4,15 @@
 // GET /api/shares/:slug(*) — list active shares for slug (requires login)
 // DELETE /api/shares/:slug(*) — revoke all shares for slug (requires login + CSRF)
 
-import { createShare, getActiveShareToken, revokeShare, revokeAllForSlug, listSharesForSlug } from '../sharing/share-manager.js';
-import { normalizeSlug } from '../utils/slug.js';
+import {
+  createShare,
+  createShareAccessCookie,
+  createShareScopeCookie,
+  getActiveShare,
+  revokeShare,
+  revokeAllForSlug,
+  listSharesForSlug,
+} from '../sharing/share-manager.js';
 import { logger } from '../utils/logger.js';
 import { browserBaseFromRequest, browserPath } from '../lib/browser-base.js';
 
@@ -70,8 +77,15 @@ function absoluteUrl(req, path) {
   return `${proto}://${host}${path}`;
 }
 
-function longSharePath(browserBase, slug, token) {
-  return `${browserPath(browserBase, slug)}?token=${encodeURIComponent(token)}`;
+function appendSetCookie(res, cookie) {
+  const current = res.getHeader('Set-Cookie');
+  if (!current) {
+    res.setHeader('Set-Cookie', cookie);
+  } else if (Array.isArray(current)) {
+    res.setHeader('Set-Cookie', [...current, cookie]);
+  } else {
+    res.setHeader('Set-Cookie', [current, cookie]);
+  }
 }
 
 /**
@@ -83,14 +97,18 @@ function longSharePath(browserBase, slug, token) {
 export function setupShareApi(app, sharingConfig) {
   // GET /s/:tokenId — short share link redirect
   app.get('/s/:tokenId', (req, res) => {
-    const share = getActiveShareToken(req.params.tokenId);
+    const share = getActiveShare(req.params.tokenId);
     if (!share) {
       return res.status(404).send('Share not found');
     }
 
     const browserBase = browserBaseFromRequest(req);
+    const accessCookie = createShareAccessCookie(share.slug, share.tokenId, share.expiresAt);
+    const scopeCookie = createShareScopeCookie(share.slug, share.tokenId, share.expiresAt);
+    appendSetCookie(res, accessCookie.header);
+    appendSetCookie(res, scopeCookie.header);
     res.setHeader('Cache-Control', 'no-store');
-    res.redirect(302, longSharePath(browserBase, share.slug, share.token));
+    res.redirect(302, browserPath(browserBase, share.slug));
   });
 
   // POST /api/share — create a share link
@@ -115,10 +133,8 @@ export function setupShareApi(app, sharingConfig) {
 
       const result = createShare(slug, duration, sharingConfig);
 
-      const normalizedSlug = normalizeSlug(slug);
       const browserBase = browserBaseFromRequest(req);
       const shortUrl = absoluteUrl(req, browserPath(browserBase, `s/${result.tokenId}`));
-      const longUrl = absoluteUrl(req, longSharePath(browserBase, normalizedSlug, result.token));
 
       res.json({
         ok: true,
@@ -126,7 +142,6 @@ export function setupShareApi(app, sharingConfig) {
         expiresAt: result.expiresAt,
         url: shortUrl,
         shortUrl,
-        longUrl,
       });
     } catch (err) {
       const status = err.statusCode || 500;

--- a/src/security/auth.js
+++ b/src/security/auth.js
@@ -8,10 +8,14 @@ import { getPagesDb } from '../db/pages-db.js';
 import { CONFIG_PATH } from '../lib/config.js';
 import { logger } from '../utils/logger.js';
 import {
+  SHARE_ACCESS_COOKIE_NAME,
   SHARE_SCOPE_COOKIE_NAME,
+  clearShareAccessCookieHeader,
   clearShareScopeCookieHeader,
+  createShareAccessCookie,
   createShareScopeCookie,
   verifyShare,
+  verifyShareAccessCookie,
   verifyShareScopeCookie,
 } from '../sharing/share-manager.js';
 import { browserBaseFromRequest, browserPath, browserRoot, isPathWithinBase } from '../lib/browser-base.js';
@@ -179,6 +183,11 @@ function getShareScopeCookie(req) {
   return cookies[SHARE_SCOPE_COOKIE_NAME] || null;
 }
 
+function getShareAccessCookie(req) {
+  const cookies = parseCookies(req.headers.cookie);
+  return cookies[SHARE_ACCESS_COOKIE_NAME] || null;
+}
+
 function appendSetCookie(res, cookie) {
   const current = res.getHeader('Set-Cookie');
   if (!current) {
@@ -207,9 +216,31 @@ function clearShareScopeCookie(res) {
   appendSetCookie(res, clearShareScopeCookieHeader());
 }
 
+function clearShareAccessCookie(res) {
+  appendSetCookie(res, clearShareAccessCookieHeader());
+}
+
 function setShareScopeCookie(res, slug, tokenId, tokenExpiresAt) {
   const cookie = createShareScopeCookie(slug, tokenId, tokenExpiresAt);
   appendSetCookie(res, cookie.header);
+}
+
+function setShareAccessCookie(res, slug, tokenId, tokenExpiresAt) {
+  const cookie = createShareAccessCookie(slug, tokenId, tokenExpiresAt);
+  appendSetCookie(res, cookie.header);
+}
+
+function acceptShareViewer(res, result, options = {}) {
+  res.locals.viewerType = 'share';
+  res.locals.authenticated = false;
+  if (options.refreshAccessCookie) {
+    setShareAccessCookie(res, result.slug, result.tokenId, result.expiresAt);
+  }
+  if (options.refreshScopeCookie) {
+    setShareScopeCookie(res, result.slug, result.tokenId, result.expiresAt);
+  }
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Referrer-Policy', 'no-referrer');
 }
 
 // --- Brute-force protection ---
@@ -450,6 +481,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
     const remember = req.body?.remember === 'on';
     const token = createSession(remember);
     setSessionCookie(res, token, remember);
+    clearShareAccessCookie(res);
     clearShareScopeCookie(res);
 
     const next = req.body?.next;
@@ -487,6 +519,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
 
     destroySession(getSessionCookie(req));
     clearSessionCookie(res);
+    clearShareAccessCookie(res);
     const browserBase = browserBaseFromRequest(req);
     res.redirect(302, `${browserPath(browserBase, 'login')}?next=${encodeURIComponent(browserRoot(browserBase))}`);
   }
@@ -505,7 +538,21 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       return next();
     }
 
-    // Share token bypass
+    // Share access session bypass for pages and raw HTML artifacts.
+    if ((req.method === 'GET' || req.method === 'HEAD')
+        && !req.path.startsWith('/api/')
+        && !isAssetPath(req.path)
+        && req.path !== '/') {
+      const slug = req.path.slice(1);
+      const result = verifyShareAccessCookie(getShareAccessCookie(req), slug);
+      if (result.valid) {
+        acceptShareViewer(res, result, { refreshScopeCookie: true });
+        return next();
+      }
+    }
+
+    // Legacy long-token bypass. This is retained only for old links; new share
+    // creation and short-link access no longer expose or require this URL shape.
     if ((req.method === 'GET' || req.method === 'HEAD') && req.query.token
         && !req.path.startsWith('/api/')
         && !isAssetPath(req.path)
@@ -513,14 +560,22 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       const slug = req.path.slice(1);
       const result = verifyShare(req.query.token, slug);
       if (result.valid) {
-        res.locals.viewerType = 'share';
-        res.locals.authenticated = false;
-        setShareScopeCookie(res, result.slug, result.tokenId, result.expiresAt);
-        res.setHeader('Cache-Control', 'no-store');
-        res.setHeader('Referrer-Policy', 'no-referrer');
+        acceptShareViewer(res, result, { refreshAccessCookie: true, refreshScopeCookie: true });
         return next();
       }
       logger.info('share token invalid', { path: req.path, ip: getClientIp(req) });
+    }
+
+    if (req.path.startsWith('/api/state/')) {
+      const artifact = req.path.split('/')[3];
+      let result = { valid: false };
+      try {
+        if (artifact) result = verifyShareAccessCookie(getShareAccessCookie(req), artifact);
+      } catch { /* malformed encoding — treat as invalid */ }
+      if (result.valid) {
+        acceptShareViewer(res, result);
+        return next();
+      }
     }
 
     if (req.query.token && req.path.startsWith('/api/state/')) {
@@ -530,10 +585,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
         if (artifact) result = verifyShare(req.query.token, artifact);
       } catch { /* malformed encoding — treat as invalid */ }
       if (result.valid) {
-        res.locals.viewerType = 'share';
-        res.locals.authenticated = false;
-        res.setHeader('Cache-Control', 'no-store');
-        res.setHeader('Referrer-Policy', 'no-referrer');
+        acceptShareViewer(res, result);
         return next();
       }
       logger.info('state api share token invalid', { path: req.path, ip: getClientIp(req) });

--- a/src/security/auth.js
+++ b/src/security/auth.js
@@ -388,7 +388,7 @@ function loginPageHtml(baseUrl, error, next) {
  * Browser-visible paths are derived from X-Forwarded-Prefix when Caddy strips
  * /pages before proxying; direct localhost access uses root-relative URLs.
  */
-export function setupAuth(app, authConfig) {
+export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
   if (authConfig.enabled && authConfig.password) {
     initSessionStore();
   }
@@ -498,7 +498,9 @@ export function setupAuth(app, authConfig) {
     const browserBase = browserBaseFromRequest(req);
     if (!authConfig.enabled || !authConfig.password) return next();
 
+    const shortShareEnabled = sharingConfig?.enabled !== false;
     if (req.path.startsWith('/_assets')
+        || (shortShareEnabled && /^\/s\/[a-f0-9]{32}$/.test(req.path))
         || req.path === loginPath || req.path === logoutPath) {
       return next();
     }

--- a/src/sharing/share-manager.js
+++ b/src/sharing/share-manager.js
@@ -163,6 +163,25 @@ export function createShare(slug, duration, sharingConfig = {}) {
 }
 
 /**
+ * Rebuild an active share token from its persisted token id.
+ * Used by short links so shares.json still does not store full tokens.
+ * @param {string} tokenId
+ * @returns {{ token: string, tokenId: string, slug: string, expiresAt: number } | null}
+ */
+export function getActiveShareToken(tokenId) {
+  if (!/^[a-f0-9]{32}$/.test(tokenId || '')) return null;
+
+  const s = loadState();
+  const record = s.shares[tokenId];
+  if (!record || record.revoked) return null;
+  if (record.expiresAt !== 0 && Date.now() > record.expiresAt) return null;
+
+  const hmac = computeHmac(record.slug, record.expiresAt, tokenId, s.secret);
+  const token = encodeToken(record.slug, record.expiresAt, tokenId, hmac);
+  return { token, tokenId, slug: record.slug, expiresAt: record.expiresAt };
+}
+
+/**
  * Verify a share token.
  * @param {string} token - The share token from query string
  * @param {string} requestSlug - The slug being accessed (will be normalized)

--- a/src/sharing/share-manager.js
+++ b/src/sharing/share-manager.js
@@ -1,9 +1,10 @@
-// Share token manager — HMAC-signed stateless tokens with shares.json persistence
-// Implements the agreed design: HMAC-SHA256(slug + expiresAt + tokenId, secret)
+// DB-backed share manager. Short links are the primary access model; legacy
+// long HMAC tokens are verified only for backwards compatibility.
 
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { getPagesDb } from '../db/pages-db.js';
 import { DATA_DIR } from '../lib/config.js';
 import { normalizeSlug } from '../utils/slug.js';
 import { logger } from '../utils/logger.js';
@@ -11,10 +12,13 @@ import { logger } from '../utils/logger.js';
 const SHARES_PATH = path.join(DATA_DIR, 'shares.json');
 const SECRET_BYTES = 32;
 const TOKEN_ID_BYTES = 16;
-export const SHARE_SCOPE_COOKIE_NAME = '__Host-share_scope';
+const SHARE_ACCESS_BYTES = 32;
+const SHARE_SESSION_MAX_AGE_SECONDS = 3600;
 const SHARE_SCOPE_MAX_AGE_SECONDS = 3600;
 
-// Duration presets → milliseconds
+export const SHARE_ACCESS_COOKIE_NAME = '__Host-share_access';
+export const SHARE_SCOPE_COOKIE_NAME = '__Host-share_scope';
+
 const DURATION_MAP = {
   '24h': 24 * 60 * 60 * 1000,
   '7d': 7 * 24 * 60 * 60 * 1000,
@@ -22,56 +26,167 @@ const DURATION_MAP = {
   permanent: 0,
 };
 
-// In-memory state (loaded from disk)
-let state = null;
-let writeLock = false;
+let db;
+let initialized = false;
+let _getMeta;
+let _setMeta;
+let _insertShare;
+let _getShare;
+let _revokeShare;
+let _revokeAllForSlug;
+let _listSharesForSlug;
+let _deleteExpiredShares;
+let _insertShareSession;
+let _getShareSession;
+let _touchShareSession;
+let _deleteShareSession;
+let _deleteExpiredShareSessions;
 
-// --- Persistence ---
+function sha256(data) {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
 
-function loadState() {
-  if (state) return state;
+function nowMs() {
+  return Date.now();
+}
+
+function isTokenId(value) {
+  return /^[a-f0-9]{32}$/.test(value || '');
+}
+
+function initShareStore() {
+  if (initialized) return;
+  db = getPagesDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS share_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS shares (
+      token_id TEXT PRIMARY KEY,
+      slug TEXT NOT NULL,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      revoked INTEGER NOT NULL DEFAULT 0,
+      revoked_at INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS idx_shares_slug_created ON shares(slug, created_at DESC);
+    CREATE TABLE IF NOT EXISTS share_sessions (
+      token_hash TEXT PRIMARY KEY,
+      token_id TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      last_activity_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      FOREIGN KEY(token_id) REFERENCES shares(token_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_share_sessions_token_id ON share_sessions(token_id);
+  `);
+
+  _getMeta = db.prepare('SELECT value FROM share_meta WHERE key = ?');
+  _setMeta = db.prepare('INSERT OR REPLACE INTO share_meta (key, value) VALUES (?, ?)');
+  _insertShare = db.prepare(`
+    INSERT OR IGNORE INTO shares (token_id, slug, expires_at, created_at, revoked, revoked_at)
+    VALUES (@tokenId, @slug, @expiresAt, @createdAt, @revoked, @revokedAt)
+  `);
+  _getShare = db.prepare('SELECT * FROM shares WHERE token_id = ?');
+  _revokeShare = db.prepare('UPDATE shares SET revoked = 1, revoked_at = ? WHERE token_id = ? AND revoked = 0');
+  _revokeAllForSlug = db.prepare('UPDATE shares SET revoked = 1, revoked_at = ? WHERE slug = ? AND revoked = 0');
+  _listSharesForSlug = db.prepare(`
+    SELECT token_id, expires_at, created_at
+    FROM shares
+    WHERE slug = ? AND revoked = 0 AND (expires_at = 0 OR expires_at > ?)
+    ORDER BY created_at DESC
+  `);
+  _deleteExpiredShares = db.prepare('DELETE FROM shares WHERE expires_at != 0 AND expires_at <= ?');
+  _insertShareSession = db.prepare(`
+    INSERT OR REPLACE INTO share_sessions (token_hash, token_id, slug, created_at, last_activity_at, expires_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  _getShareSession = db.prepare(`
+    SELECT share_sessions.*, shares.expires_at AS share_expires_at, shares.revoked AS share_revoked
+    FROM share_sessions
+    JOIN shares ON shares.token_id = share_sessions.token_id
+    WHERE share_sessions.token_hash = ?
+  `);
+  _touchShareSession = db.prepare('UPDATE share_sessions SET last_activity_at = ? WHERE token_hash = ?');
+  _deleteShareSession = db.prepare('DELETE FROM share_sessions WHERE token_hash = ?');
+  _deleteExpiredShareSessions = db.prepare('DELETE FROM share_sessions WHERE expires_at <= ?');
+
+  importLegacySharesJson();
+  initialized = true;
+}
+
+function readLegacyState() {
   try {
-    if (fs.existsSync(SHARES_PATH)) {
-      const raw = fs.readFileSync(SHARES_PATH, 'utf-8');
-      state = JSON.parse(raw);
-      // Ensure structure
-      if (!state.secret || !state.shares) throw new Error('invalid');
-    } else {
-      state = {
-        secret: crypto.randomBytes(SECRET_BYTES).toString('hex'),
-        shares: {},
-      };
-      saveState();
+    if (!fs.existsSync(SHARES_PATH)) return null;
+    const raw = fs.readFileSync(SHARES_PATH, 'utf-8');
+    const state = JSON.parse(raw);
+    if (!state || typeof state !== 'object' || !state.secret || !state.shares) return null;
+    return state;
+  } catch (err) {
+    logger.warn('legacy shares.json unreadable, skipping import', { err: err.message });
+    return null;
+  }
+}
+
+function importLegacySharesJson() {
+  const imported = _getMeta.get('legacy_shares_json_imported')?.value;
+  const legacy = readLegacyState();
+
+  if (!_getMeta.get('secret')?.value) {
+    const secret = legacy?.secret || crypto.randomBytes(SECRET_BYTES).toString('hex');
+    _setMeta.run('secret', secret);
+  }
+
+  if (imported || !legacy) return;
+
+  const insertMany = db.transaction((shares) => {
+    for (const [tokenId, record] of Object.entries(shares)) {
+      if (!isTokenId(tokenId) || !record || typeof record !== 'object') continue;
+      try {
+        _insertShare.run({
+          tokenId,
+          slug: normalizeSlug(record.slug),
+          expiresAt: Number(record.expiresAt) || 0,
+          createdAt: Number(record.createdAt) || nowMs(),
+          revoked: record.revoked ? 1 : 0,
+          revokedAt: record.revokedAt ? Number(record.revokedAt) : null,
+        });
+      } catch (err) {
+        logger.warn('legacy share skipped during import', { tokenId, err: err.message });
+      }
     }
-  } catch (err) {
-    logger.warn('shares.json corrupted, reinitializing', { err: err.message });
-    state = {
-      secret: crypto.randomBytes(SECRET_BYTES).toString('hex'),
-      shares: {},
-    };
-    saveState();
-  }
-  return state;
+    _setMeta.run('legacy_shares_json_imported', String(nowMs()));
+  });
+
+  insertMany(legacy.shares);
+  logger.info('legacy shares.json imported into DB', { count: Object.keys(legacy.shares).length });
 }
 
-function saveState() {
-  if (!state) return;
-  if (writeLock) return; // skip concurrent writes; next mutation will flush
-  writeLock = true;
-  try {
-    const tmp = SHARES_PATH + '.tmp.' + process.pid;
-    fs.writeFileSync(tmp, JSON.stringify(state, null, 2), { mode: 0o600 });
-    fs.renameSync(tmp, SHARES_PATH);
-    // Ensure final file permissions
-    fs.chmodSync(SHARES_PATH, 0o600);
-  } catch (err) {
-    logger.error('failed to save shares.json', { err: err.message });
-  } finally {
-    writeLock = false;
+function getSecret() {
+  initShareStore();
+  let secret = _getMeta.get('secret')?.value;
+  if (!secret) {
+    secret = crypto.randomBytes(SECRET_BYTES).toString('hex');
+    _setMeta.run('secret', secret);
   }
+  return secret;
 }
 
-// --- HMAC Token ---
+function activeShareRecord(tokenId) {
+  if (!isTokenId(tokenId)) return null;
+  initShareStore();
+  const record = _getShare.get(tokenId);
+  if (!record || record.revoked) return null;
+  if (record.expires_at !== 0 && nowMs() > record.expires_at) return null;
+  return {
+    tokenId: record.token_id,
+    slug: record.slug,
+    expiresAt: record.expires_at,
+    createdAt: record.created_at,
+  };
+}
 
 function computeHmac(slug, expiresAt, tokenId, secret) {
   const payload = `${slug}:${expiresAt}:${tokenId}`;
@@ -90,7 +205,6 @@ function decodeToken(token) {
     const raw = Buffer.from(token, 'base64url').toString('utf-8');
     const parts = raw.split(':');
     if (parts.length < 4) return null;
-    // HMAC is the last part; slug may contain colons (unlikely but safe)
     const hmacHex = parts.pop();
     const tokenId = parts.pop();
     const expiresAt = parts.pop();
@@ -100,6 +214,11 @@ function decodeToken(token) {
   } catch {
     return null;
   }
+}
+
+function legacyTokenFor(record) {
+  const hmac = computeHmac(record.slug, record.expiresAt, record.tokenId, getSecret());
+  return encodeToken(record.slug, record.expiresAt, record.tokenId, hmac);
 }
 
 function directoryScope(slug) {
@@ -121,17 +240,14 @@ function isAssetWithinScope(assetPath, directory) {
   return assetDir === directory || assetDir.startsWith(`${directory}/`);
 }
 
-// --- Public API ---
+function cookieMaxAge(tokenExpiresAt, maxAgeSeconds) {
+  if (tokenExpiresAt === 0) return maxAgeSeconds;
+  const remaining = Math.max(0, Math.floor((tokenExpiresAt - nowMs()) / 1000));
+  return Math.max(0, Math.min(maxAgeSeconds, remaining));
+}
 
-/**
- * Create a share token for a document.
- * @param {string} slug - Document slug (will be normalized)
- * @param {string} duration - '24h' | '7d' | '30d' | 'permanent'
- * @param {object} sharingConfig - { allowPermanent }
- * @returns {{ token: string, tokenId: string, expiresAt: number }}
- */
 export function createShare(slug, duration, sharingConfig = {}) {
-  const s = loadState();
+  initShareStore();
   const normalizedSlug = normalizeSlug(slug);
 
   if (duration === 'permanent' && !sharingConfig.allowPermanent) {
@@ -144,99 +260,111 @@ export function createShare(slug, duration, sharingConfig = {}) {
   }
 
   const tokenId = crypto.randomBytes(TOKEN_ID_BYTES).toString('hex');
-  const expiresAt = durationMs === 0 ? 0 : Date.now() + durationMs;
-  const hmac = computeHmac(normalizedSlug, expiresAt, tokenId, s.secret);
-  const token = encodeToken(normalizedSlug, expiresAt, tokenId, hmac);
+  const createdAt = nowMs();
+  const expiresAt = durationMs === 0 ? 0 : createdAt + durationMs;
+  const record = { tokenId, slug: normalizedSlug, expiresAt, createdAt };
 
-  // Store metadata (never store the full token)
-  s.shares[tokenId] = {
+  _insertShare.run({
+    tokenId,
     slug: normalizedSlug,
     expiresAt,
-    createdAt: Date.now(),
-    revoked: false,
-  };
-  saveState();
+    createdAt,
+    revoked: 0,
+    revokedAt: null,
+  });
 
   logger.info('share created', { slug: normalizedSlug, tokenId, duration, expiresAt });
-
-  return { token, tokenId, expiresAt };
+  return { token: legacyTokenFor(record), tokenId, expiresAt };
 }
 
-/**
- * Rebuild an active share token from its persisted token id.
- * Used by short links so shares.json still does not store full tokens.
- * @param {string} tokenId
- * @returns {{ token: string, tokenId: string, slug: string, expiresAt: number } | null}
- */
+export function getActiveShare(tokenId) {
+  return activeShareRecord(tokenId);
+}
+
 export function getActiveShareToken(tokenId) {
-  if (!/^[a-f0-9]{32}$/.test(tokenId || '')) return null;
-
-  const s = loadState();
-  const record = s.shares[tokenId];
-  if (!record || record.revoked) return null;
-  if (record.expiresAt !== 0 && Date.now() > record.expiresAt) return null;
-
-  const hmac = computeHmac(record.slug, record.expiresAt, tokenId, s.secret);
-  const token = encodeToken(record.slug, record.expiresAt, tokenId, hmac);
-  return { token, tokenId, slug: record.slug, expiresAt: record.expiresAt };
+  const record = activeShareRecord(tokenId);
+  if (!record) return null;
+  return { ...record, token: legacyTokenFor(record) };
 }
 
-/**
- * Verify a share token.
- * @param {string} token - The share token from query string
- * @param {string} requestSlug - The slug being accessed (will be normalized)
- * @returns {{ valid: boolean, slug?: string, viewerType?: string }}
- */
+export function createShareAccessCookie(slug, tokenId, tokenExpiresAt) {
+  initShareStore();
+  const maxAge = cookieMaxAge(tokenExpiresAt, SHARE_SESSION_MAX_AGE_SECONDS);
+  const token = crypto.randomBytes(SHARE_ACCESS_BYTES).toString('hex');
+  const createdAt = nowMs();
+  const expiresAt = createdAt + maxAge * 1000;
+  _insertShareSession.run(sha256(token), tokenId, normalizeSlug(slug), createdAt, createdAt, expiresAt);
+  return {
+    value: token,
+    maxAge,
+    header: `${SHARE_ACCESS_COOKIE_NAME}=${token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${maxAge}`,
+  };
+}
+
+export function clearShareAccessCookieHeader() {
+  return `${SHARE_ACCESS_COOKIE_NAME}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0`;
+}
+
+export function verifyShareAccessCookie(cookieValue, requestSlug) {
+  initShareStore();
+  if (!cookieValue || typeof cookieValue !== 'string') return { valid: false };
+  const hash = sha256(cookieValue);
+  const session = _getShareSession.get(hash);
+  if (!session) return { valid: false };
+
+  const current = nowMs();
+  if (current > session.expires_at ||
+      session.share_revoked ||
+      (session.share_expires_at !== 0 && current > session.share_expires_at)) {
+    _deleteShareSession.run(hash);
+    return { valid: false };
+  }
+
+  const normalizedRequest = normalizeSlug(requestSlug);
+  if (normalizeSlug(session.slug) !== normalizedRequest) return { valid: false };
+
+  _touchShareSession.run(current, hash);
+  return {
+    valid: true,
+    slug: session.slug,
+    tokenId: session.token_id,
+    expiresAt: session.share_expires_at,
+    viewerType: 'share',
+  };
+}
+
 export function verifyShare(token, requestSlug) {
-  const s = loadState();
   const decoded = decodeToken(token);
   if (!decoded) return { valid: false };
 
   const normalizedRequest = normalizeSlug(requestSlug);
   const normalizedToken = normalizeSlug(decoded.slug);
+  if (normalizedToken !== normalizedRequest) return { valid: false };
+  if (decoded.expiresAt !== 0 && nowMs() > decoded.expiresAt) return { valid: false };
+  if (!isTokenId(decoded.tokenId)) return { valid: false };
 
-  // Slug must match
-  if (normalizedToken !== normalizedRequest) {
-    return { valid: false };
-  }
-
-  // Check expiration
-  if (decoded.expiresAt !== 0 && Date.now() > decoded.expiresAt) {
-    return { valid: false };
-  }
-
-  // Recompute HMAC and timing-safe compare
-  const expected = computeHmac(normalizedToken, decoded.expiresAt, decoded.tokenId, s.secret);
+  const expected = computeHmac(normalizedToken, decoded.expiresAt, decoded.tokenId, getSecret());
   if (expected.length !== decoded.hmac.length) return { valid: false };
-  if (!crypto.timingSafeEqual(expected, decoded.hmac)) {
-    return { valid: false };
-  }
+  if (!crypto.timingSafeEqual(expected, decoded.hmac)) return { valid: false };
 
-  // Check revocation and record consistency
-  const record = s.shares[decoded.tokenId];
-  if (record) {
-    if (record.revoked) return { valid: false };
-    // Cross-check: record fields must match token claims
-    if (record.slug !== normalizedToken || record.expiresAt !== decoded.expiresAt) {
-      return { valid: false };
-    }
-  }
-  // Note: if record is missing (e.g. never existed), the HMAC is still valid.
-  // This is the "stateless" path — only revocation requires the record.
+  const record = activeShareRecord(decoded.tokenId);
+  if (!record) return { valid: false };
+  if (record.slug !== normalizedToken || record.expiresAt !== decoded.expiresAt) return { valid: false };
 
-  return { valid: true, slug: normalizedToken, tokenId: decoded.tokenId, expiresAt: decoded.expiresAt, viewerType: 'share' };
+  return {
+    valid: true,
+    slug: normalizedToken,
+    tokenId: decoded.tokenId,
+    expiresAt: decoded.expiresAt,
+    viewerType: 'share',
+  };
 }
 
 export function createShareScopeCookie(slug, tokenId, tokenExpiresAt) {
-  const s = loadState();
-  const now = Date.now();
-  const tokenRemainingMs = tokenExpiresAt === 0
-    ? SHARE_SCOPE_MAX_AGE_SECONDS * 1000
-    : Math.max(0, tokenExpiresAt - now);
-  const maxAge = Math.max(0, Math.min(SHARE_SCOPE_MAX_AGE_SECONDS, Math.floor(tokenRemainingMs / 1000)));
-  const expiresAt = now + maxAge * 1000;
+  const maxAge = cookieMaxAge(tokenExpiresAt, SHARE_SCOPE_MAX_AGE_SECONDS);
+  const expiresAt = nowMs() + maxAge * 1000;
   const directory = directoryScope(slug);
-  const hmac = computeShareScopeHmac(directory, tokenId, expiresAt, s.secret);
+  const hmac = computeShareScopeHmac(directory, tokenId, expiresAt, getSecret());
   const value = `${directory}:${tokenId}:${expiresAt}:${hmac}`;
   return {
     value,
@@ -250,7 +378,6 @@ export function clearShareScopeCookieHeader() {
 }
 
 export function verifyShareScopeCookie(cookieValue, assetPath) {
-  const s = loadState();
   if (!cookieValue || typeof cookieValue !== 'string') return { valid: false };
 
   const parts = cookieValue.split(':');
@@ -260,18 +387,17 @@ export function verifyShareScopeCookie(cookieValue, assetPath) {
   const tokenId = parts.pop();
   const directory = parts.join(':');
   const expiresAt = Number(expiresAtRaw);
-  if (!tokenId || !Number.isFinite(expiresAt) || !hmac) return { valid: false };
-  if (Date.now() > expiresAt) return { valid: false };
+  if (!isTokenId(tokenId) || !Number.isFinite(expiresAt) || !hmac) return { valid: false };
+  if (nowMs() > expiresAt) return { valid: false };
 
-  const expected = computeShareScopeHmac(directory, tokenId, expiresAt, s.secret);
+  const expected = computeShareScopeHmac(directory, tokenId, expiresAt, getSecret());
   const actualBuffer = Buffer.from(hmac, 'hex');
   const expectedBuffer = Buffer.from(expected, 'hex');
   if (actualBuffer.length !== expectedBuffer.length) return { valid: false };
   if (!crypto.timingSafeEqual(actualBuffer, expectedBuffer)) return { valid: false };
 
-  const record = s.shares[tokenId];
-  if (!record || record.revoked) return { valid: false };
-  if (record.expiresAt !== 0 && Date.now() > record.expiresAt) return { valid: false };
+  const record = activeShareRecord(tokenId);
+  if (!record) return { valid: false };
   if (directoryScope(record.slug) !== directory) return { valid: false };
 
   try {
@@ -283,110 +409,48 @@ export function verifyShareScopeCookie(cookieValue, assetPath) {
   return { valid: true, directory, viewerType: 'share' };
 }
 
-/**
- * Revoke a specific share by tokenId.
- * @param {string} tokenId
- * @returns {boolean} true if found and revoked
- */
 export function revokeShare(tokenId) {
-  const s = loadState();
-  const record = s.shares[tokenId];
+  if (!isTokenId(tokenId)) return false;
+  initShareStore();
+  const record = _getShare.get(tokenId);
   if (!record) return false;
-  record.revoked = true;
-  record.revokedAt = Date.now();
-  saveState();
-  logger.info('share revoked', { tokenId, slug: record.slug });
-  return true;
+  const result = _revokeShare.run(nowMs(), tokenId);
+  if (result.changes > 0) {
+    logger.info('share revoked', { tokenId, slug: record.slug });
+  }
+  return result.changes > 0;
 }
 
-/**
- * Revoke all active shares for a slug.
- * @param {string} slug
- * @returns {number} count of revoked shares
- */
 export function revokeAllForSlug(slug) {
-  const s = loadState();
+  initShareStore();
   const normalizedSlug = normalizeSlug(slug);
-  let count = 0;
-  const now = Date.now();
-  for (const [id, record] of Object.entries(s.shares)) {
-    if (record.slug === normalizedSlug && !record.revoked) {
-      record.revoked = true;
-      record.revokedAt = now;
-      count++;
-    }
+  const result = _revokeAllForSlug.run(nowMs(), normalizedSlug);
+  if (result.changes > 0) {
+    logger.info('shares revoked for slug', { slug: normalizedSlug, count: result.changes });
   }
-  if (count > 0) {
-    saveState();
-    logger.info('shares revoked for slug', { slug: normalizedSlug, count });
-  }
-  return count;
+  return result.changes;
 }
 
-/**
- * List active (non-revoked, non-expired) shares for a slug.
- * Returns metadata only — never the full token.
- * @param {string} slug
- * @returns {Array<{ tokenId, expiresAt, createdAt }>}
- */
 export function listSharesForSlug(slug) {
-  const s = loadState();
+  initShareStore();
   const normalizedSlug = normalizeSlug(slug);
-  const now = Date.now();
-  const result = [];
-
-  for (const [tokenId, record] of Object.entries(s.shares)) {
-    if (record.slug !== normalizedSlug) continue;
-    if (record.revoked) continue;
-    if (record.expiresAt !== 0 && now > record.expiresAt) continue;
-    result.push({
-      tokenId,
-      expiresAt: record.expiresAt,
-      createdAt: record.createdAt,
-    });
-  }
-
-  // Sort newest first
-  result.sort((a, b) => b.createdAt - a.createdAt);
-  return result;
+  return _listSharesForSlug.all(normalizedSlug, nowMs()).map(record => ({
+    tokenId: record.token_id,
+    expiresAt: record.expires_at,
+    createdAt: record.created_at,
+  }));
 }
 
-/**
- * Clean up share records that are safe to remove.
- * Called periodically (hourly).
- *
- * IMPORTANT: Revoked records are tombstones — they MUST be kept until the
- * token's natural expiry to prevent "resurrection" (HMAC is still valid
- * without the tombstone). Only delete:
- * - Expired records (revoked or not) — token is naturally invalid
- * - Revoked permanent tokens: NEVER deleted (tombstone is permanent)
- */
 export function cleanupShares() {
-  const s = loadState();
-  const now = Date.now();
-  let removed = 0;
-
-  for (const [tokenId, record] of Object.entries(s.shares)) {
-    const expired = record.expiresAt !== 0 && now > record.expiresAt;
-
-    if (expired) {
-      // Token naturally expired — safe to remove regardless of revocation
-      delete s.shares[tokenId];
-      removed++;
-    }
-    // Revoked non-permanent tokens: keep tombstone until natural expiry
-    // Revoked permanent tokens (expiresAt=0): tombstone kept forever
-  }
-
-  if (removed > 0) {
-    saveState();
-    logger.info('shares cleanup', { removed });
+  initShareStore();
+  const current = nowMs();
+  const sessions = _deleteExpiredShareSessions.run(current).changes;
+  const shares = _deleteExpiredShares.run(current).changes;
+  if (sessions > 0 || shares > 0) {
+    logger.info('shares cleanup', { removedShares: shares, removedSessions: sessions });
   }
 }
 
-/**
- * Get the valid duration keys.
- */
 export function getValidDurations() {
   return Object.keys(DURATION_MAP);
 }

--- a/test/asset-route.test.js
+++ b/test/asset-route.test.js
@@ -12,6 +12,7 @@ const express = (await import('express')).default;
 const { initCache } = await import('../src/cache/pageCache.js');
 const { setupAssetRoute } = await import('../src/routes/asset.js');
 const { pageRoute } = await import('../src/routes/pages.js');
+const { setupShareApi } = await import('../src/routes/share-api.js');
 const { setupStateApi } = await import('../src/routes/state-api.js');
 const { setupAuth, hashPassword } = await import('../src/security/auth.js');
 const { securityHeaders } = await import('../src/security/headers.js');
@@ -49,6 +50,7 @@ async function withServer(config, fn) {
   const app = express();
   app.use(securityHeaders());
   setupAuth(app, config.auth || { enabled: false, password: null });
+  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false });
   setupStateApi(app);
   app.get('/', (_req, res) => res.send('root'));
   setupAssetRoute(app, config);
@@ -94,6 +96,13 @@ function shareScopeCookie(setCookieHeader) {
   const match = setCookieHeader.match(/__Host-share_scope=([^;,]+)/);
   assert.ok(match, 'share-scope cookie should be present');
   return `${SHARE_SCOPE_COOKIE_NAME}=${match[1]}`;
+}
+
+function cookieHeader(setCookieHeader) {
+  return setCookieHeader
+    .split(/,\s*(?=__Host-)/)
+    .map(cookie => cookie.split(';', 1)[0])
+    .join('; ');
 }
 
 function expectLoginRedirect(response) {
@@ -194,13 +203,20 @@ test('share page access sets scoped cookie and asset request uses cookie without
     await writeFile(path.join(contentDir, 'direct-token.jpg'), 'direct token image');
     await mkdir(path.join(contentDir, 'docs'));
     await writeFile(path.join(contentDir, 'docs', 'nested.jpg'), 'nested image');
-    const token = createShare('renovation-checklist', '24h', { allowPermanent: false }).token;
+    const share = createShare('renovation-checklist', '24h', { allowPermanent: false });
     const assetToken = createShare('direct-token.jpg', '24h', { allowPermanent: false }).token;
 
     await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
-      const page = await fetch(`${origin}/renovation-checklist?token=${encodeURIComponent(token)}`);
+      const redirect = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
+      assert.equal(redirect.status, 302);
+      assert.equal(redirect.headers.get('location'), '/renovation-checklist');
+      assert.doesNotMatch(redirect.headers.get('location'), /token=/);
+
+      const page = await fetch(`${origin}/renovation-checklist`, {
+        headers: { Cookie: cookieHeader(redirect.headers.get('set-cookie')) },
+      });
       assert.equal(page.status, 200);
-      const setCookie = page.headers.get('set-cookie');
+      const setCookie = redirect.headers.get('set-cookie');
       assert.match(setCookie, /__Host-share_scope=/);
       assert.match(setCookie, /HttpOnly/);
       assert.match(setCookie, /Secure/);
@@ -214,7 +230,7 @@ test('share page access sets scoped cookie and asset request uses cookie without
       assert.equal(await res.text(), 'kitchen image');
       assert.equal(res.headers.get('cache-control'), 'no-store');
 
-      res = await fetch(`${origin}/kitchen-ref.jpg?token=${encodeURIComponent(token)}`, { redirect: 'manual' });
+      res = await fetch(`${origin}/kitchen-ref.jpg?token=${encodeURIComponent(share.token)}`, { redirect: 'manual' });
       expectAssetDenied(res);
 
       res = await fetch(`${origin}/direct-token.jpg?token=${encodeURIComponent(assetToken)}`, { redirect: 'manual' });

--- a/test/html-artifacts.test.js
+++ b/test/html-artifacts.test.js
@@ -14,6 +14,7 @@ const { getPage } = await import('../src/services/pageService.js');
 const { indexRoute, scanPages } = await import('../src/routes/index.js');
 const { pageRoute } = await import('../src/routes/pages.js');
 const { setupRawApi } = await import('../src/routes/raw-api.js');
+const { setupShareApi } = await import('../src/routes/share-api.js');
 const { setupAuth, hashPassword } = await import('../src/security/auth.js');
 const { DEFAULT_CSP, HTML_ARTIFACT_CSP, securityHeaders } = await import('../src/security/headers.js');
 const { resolvePageDescriptor, resolveSafePath } = await import('../src/security/pathGuard.js');
@@ -38,6 +39,13 @@ function baseConfig(contentDir) {
   };
 }
 
+function cookieHeader(setCookie) {
+  return setCookie
+    .split(/,\s*(?=__Host-)/)
+    .map(cookie => cookie.split(';', 1)[0])
+    .join('; ');
+}
+
 async function makeContentDir() {
   return mkdtemp(path.join(os.tmpdir(), 'zylos-pages-html-content-'));
 }
@@ -47,6 +55,7 @@ async function withServer(config, fn) {
   const app = express();
   app.use(securityHeaders());
   setupAuth(app, config.auth || { enabled: false, password: null });
+  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false });
   setupRawApi(app, config);
   app.get('/', indexRoute(config));
   app.get('/:slug(*)', pageRoute(config));
@@ -193,15 +202,17 @@ test('html extension redirect preserves query string for share tokens', async ()
       assert.match(sharedBody, /html-artifact-frame/);
       assert.match(sharedBody, /data-viewer="share"/);
 
-      // iframe src must include token so share viewer can load raw content
+      // iframe src uses the share access cookie, not a long token URL.
       const iframeSrcMatch = sharedBody.match(/<iframe[^>]+src="([^"]+)"/);
       assert.ok(iframeSrcMatch, 'iframe src must be present');
       assert.match(iframeSrcMatch[1], /raw=1/);
-      assert.match(iframeSrcMatch[1], /token=/);
+      assert.doesNotMatch(iframeSrcMatch[1], /token=/);
 
       // Fetch the actual iframe src — must return 200 with artifact content
       const iframeUrl = iframeSrcMatch[1].replace(/&amp;/g, '&');
-      const iframeFetch = await fetch(`${origin}${iframeUrl}`);
+      const iframeFetch = await fetch(`${origin}${iframeUrl}`, {
+        headers: { Cookie: cookieHeader(shared.headers.get('set-cookie')) },
+      });
       assert.equal(iframeFetch.status, 200);
       assert.match(await iframeFetch.text(), /Shared HTML/);
     });

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -16,6 +16,13 @@ test.after(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+function cookieHeader(setCookie) {
+  return setCookie
+    .split(/,\s*(?=__Host-)/)
+    .map(cookie => cookie.split(';', 1)[0])
+    .join('; ');
+}
+
 function makeServer({ auth = false, sharingEnabled = true } = {}) {
   const app = express();
   if (auth) {
@@ -43,7 +50,7 @@ function makeServer({ auth = false, sharingEnabled = true } = {}) {
   });
 }
 
-test('create share returns short URL by default and preserves long URL', async () => {
+test('create share returns short URL only', async () => {
   const { server, origin } = await makeServer();
   try {
     const response = await fetch(`${origin}/api/share`, {
@@ -62,13 +69,13 @@ test('create share returns short URL by default and preserves long URL', async (
     assert.match(body.tokenId, /^[a-f0-9]{32}$/);
     assert.equal(body.url, `${origin}/s/${body.tokenId}`);
     assert.equal(body.shortUrl, body.url);
-    assert.match(body.longUrl, new RegExp(`^${origin}/docs/page\\?token=`));
+    assert.equal(Object.prototype.hasOwnProperty.call(body, 'longUrl'), false);
   } finally {
     server.close();
   }
 });
 
-test('short share URL redirects to token URL', async () => {
+test('short share URL sets share cookies and redirects to clean page URL', async () => {
   const { server, origin } = await makeServer();
   try {
     const create = await fetch(`${origin}/api/share`, {
@@ -84,13 +91,17 @@ test('short share URL redirects to token URL', async () => {
 
     const redirect = await fetch(share.url, { redirect: 'manual' });
     assert.equal(redirect.status, 302);
-    assert.match(redirect.headers.get('location'), /^\/docs\/page\?token=/);
+    assert.equal(redirect.headers.get('location'), '/docs/page');
+    const setCookie = redirect.headers.get('set-cookie');
+    assert.match(setCookie, /__Host-share_access=/);
+    assert.match(setCookie, /__Host-share_scope=/);
+    assert.doesNotMatch(redirect.headers.get('location'), /token=/);
   } finally {
     server.close();
   }
 });
 
-test('auth middleware allows short share URLs through to redirect route', async () => {
+test('auth middleware allows short share URL cookies to access target page', async () => {
   const { server, origin } = await makeServer({ auth: true });
   try {
     const login = await fetch(`${origin}/login`, {
@@ -118,7 +129,15 @@ test('auth middleware allows short share URLs through to redirect route', async 
     const redirect = await fetch(share.url, { redirect: 'manual' });
     assert.equal(redirect.status, 302);
     assert.doesNotMatch(redirect.headers.get('location'), /login/);
-    assert.match(redirect.headers.get('location'), /^\/docs\/page\?token=/);
+    assert.equal(redirect.headers.get('location'), '/docs/page');
+    const cookies = cookieHeader(redirect.headers.get('set-cookie'));
+
+    const page = await fetch(`${origin}/docs/page`, {
+      redirect: 'manual',
+      headers: { Cookie: cookies },
+    });
+    assert.equal(page.status, 200);
+    assert.equal(await page.text(), 'plain');
   } finally {
     server.close();
   }

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-pages-share-test-'));
+process.env.PAGES_DATA_DIR = tmpDir;
+
+const express = (await import('express')).default;
+const { setupShareApi } = await import('../src/routes/share-api.js');
+const { setupAuth, hashPassword } = await import('../src/security/auth.js');
+
+test.after(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeServer({ auth = false, sharingEnabled = true } = {}) {
+  const app = express();
+  if (auth) {
+    setupAuth(app, {
+      enabled: true,
+      password: hashPassword('secret'),
+    }, { enabled: sharingEnabled });
+  }
+  if (sharingEnabled) {
+    setupShareApi(app, { enabled: true, allowPermanent: false });
+  }
+  app.get('/docs/page', (req, res) => {
+    res.status(200).send(req.query.token ? 'shared' : 'plain');
+  });
+  app.get('/s/:tokenId', (_req, res) => {
+    res.status(200).send('protected fallback route');
+  });
+
+  const server = http.createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, origin: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+test('create share returns short URL by default and preserves long URL', async () => {
+  const { server, origin } = await makeServer();
+  try {
+    const response = await fetch(`${origin}/api/share`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: origin,
+        'X-Forwarded-Proto': 'http',
+      },
+      body: JSON.stringify({ slug: 'docs/page', duration: '24h' }),
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.match(body.tokenId, /^[a-f0-9]{32}$/);
+    assert.equal(body.url, `${origin}/s/${body.tokenId}`);
+    assert.equal(body.shortUrl, body.url);
+    assert.match(body.longUrl, new RegExp(`^${origin}/docs/page\\?token=`));
+  } finally {
+    server.close();
+  }
+});
+
+test('short share URL redirects to token URL', async () => {
+  const { server, origin } = await makeServer();
+  try {
+    const create = await fetch(`${origin}/api/share`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: origin,
+        'X-Forwarded-Proto': 'http',
+      },
+      body: JSON.stringify({ slug: 'docs/page', duration: '24h' }),
+    });
+    const share = await create.json();
+
+    const redirect = await fetch(share.url, { redirect: 'manual' });
+    assert.equal(redirect.status, 302);
+    assert.match(redirect.headers.get('location'), /^\/docs\/page\?token=/);
+  } finally {
+    server.close();
+  }
+});
+
+test('auth middleware allows short share URLs through to redirect route', async () => {
+  const { server, origin } = await makeServer({ auth: true });
+  try {
+    const login = await fetch(`${origin}/login`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ password: 'secret' }),
+    });
+    const cookie = login.headers.get('set-cookie');
+    assert.match(cookie, /__Host-zylos_pages_session=/);
+
+    const create = await fetch(`${origin}/api/share`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: origin,
+        'X-Forwarded-Proto': 'http',
+        Cookie: cookie,
+      },
+      body: JSON.stringify({ slug: 'docs/page', duration: '24h' }),
+    });
+    assert.equal(create.status, 200);
+    const share = await create.json();
+
+    const redirect = await fetch(share.url, { redirect: 'manual' });
+    assert.equal(redirect.status, 302);
+    assert.doesNotMatch(redirect.headers.get('location'), /login/);
+    assert.match(redirect.headers.get('location'), /^\/docs\/page\?token=/);
+  } finally {
+    server.close();
+  }
+});
+
+test('short share URL does not bypass auth when sharing is disabled', async () => {
+  const { server, origin } = await makeServer({ auth: true, sharingEnabled: false });
+  try {
+    const response = await fetch(`${origin}/s/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`, {
+      redirect: 'manual',
+    });
+
+    assert.equal(response.status, 302);
+    assert.equal(
+      response.headers.get('location'),
+      '/login?next=%2Fs%2Faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    );
+  } finally {
+    server.close();
+  }
+});

--- a/test/share-legacy-migration.test.js
+++ b/test/share-legacy-migration.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const dataDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-share-legacy-'));
+process.env.PAGES_DATA_DIR = dataDir;
+
+const legacySecret = '11'.repeat(32);
+const legacyTokenId = 'a'.repeat(32);
+const legacySlug = 'legacy/page';
+const legacyExpiresAt = Date.now() + 86_400_000;
+const legacyCreatedAt = Date.now() - 1000;
+
+function legacyToken(slug, expiresAt, tokenId, secret) {
+  const payload = `${slug}:${expiresAt}:${tokenId}`;
+  const hmac = crypto.createHmac('sha256', Buffer.from(secret, 'hex'))
+    .update(payload)
+    .digest('hex');
+  return Buffer.from(`${payload}:${hmac}`).toString('base64url');
+}
+
+const legacyJson = JSON.stringify({
+  secret: legacySecret,
+  shares: {
+    [legacyTokenId]: {
+      slug: legacySlug,
+      expiresAt: legacyExpiresAt,
+      createdAt: legacyCreatedAt,
+      revoked: false,
+    },
+  },
+}, null, 2);
+
+await writeFile(path.join(dataDir, 'shares.json'), legacyJson, { mode: 0o600 });
+
+const {
+  createShare,
+  getActiveShare,
+  verifyShare,
+} = await import('../src/sharing/share-manager.js');
+
+test.after(async () => {
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+test('legacy shares.json imports into DB and is no longer active write storage', async () => {
+  assert.deepEqual(getActiveShare(legacyTokenId), {
+    tokenId: legacyTokenId,
+    slug: legacySlug,
+    expiresAt: legacyExpiresAt,
+    createdAt: legacyCreatedAt,
+  });
+
+  const token = legacyToken(legacySlug, legacyExpiresAt, legacyTokenId, legacySecret);
+  assert.deepEqual(verifyShare(token, legacySlug), {
+    valid: true,
+    slug: legacySlug,
+    tokenId: legacyTokenId,
+    expiresAt: legacyExpiresAt,
+    viewerType: 'share',
+  });
+
+  createShare('new/page', '24h', { allowPermanent: false });
+  assert.equal(await readFile(path.join(dataDir, 'shares.json'), 'utf8'), legacyJson);
+});

--- a/test/state-api.test.js
+++ b/test/state-api.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
@@ -12,9 +12,11 @@ process.env.PAGES_DATA_DIR = dataDir;
 const express = (await import('express')).default;
 const { setupAuth, hashPassword } = await import('../src/security/auth.js');
 const { setupRawApi } = await import('../src/routes/raw-api.js');
+const { setupShareApi } = await import('../src/routes/share-api.js');
 const { setupStateApi, RAW_BODY_LIMIT_BYTES, VALUE_JSON_LIMIT_BYTES } = await import('../src/routes/state-api.js');
 const { setupTodoApi } = await import('../src/routes/todo-api.js');
 const { createShare, revokeShare } = await import('../src/sharing/share-manager.js');
+const { getPagesDb } = await import('../src/db/pages-db.js');
 const {
   deleteStateValue,
   getArtifactState,
@@ -45,6 +47,7 @@ async function withApp(app, fn) {
 async function withServer(authConfig, fn) {
   const app = express();
   setupAuth(app, authConfig || { enabled: false, password: null });
+  setupShareApi(app, { enabled: true, allowPermanent: false });
   setupStateApi(app);
   app.get('/', (_req, res) => res.send('root'));
   await withApp(app, fn);
@@ -76,12 +79,21 @@ function sameOriginHeaders(origin, extra = {}) {
   };
 }
 
+function cookieHeader(setCookie) {
+  return setCookie
+    .split(/,\s*(?=__Host-)/)
+    .map(cookie => cookie.split(';', 1)[0])
+    .join('; ');
+}
+
 async function createExpiredShareToken(slug) {
   const share = createShare(slug, '24h', { allowPermanent: false });
-  const state = JSON.parse(await readFile(path.join(dataDir, 'shares.json'), 'utf8'));
   const expiresAt = Date.now() - 1000;
+  const db = getPagesDb();
+  const secret = db.prepare('SELECT value FROM share_meta WHERE key = ?').get('secret').value;
+  db.prepare('UPDATE shares SET expires_at = ? WHERE token_id = ?').run(expiresAt, share.tokenId);
   const payload = `${slug}:${expiresAt}:${share.tokenId}`;
-  const hmac = crypto.createHmac('sha256', Buffer.from(state.secret, 'hex'))
+  const hmac = crypto.createHmac('sha256', Buffer.from(secret, 'hex'))
     .update(payload)
     .digest('hex');
   return Buffer.from(`${payload}:${hmac}`).toString('base64url');
@@ -271,6 +283,39 @@ test('state API allows share-token CRUD for the matching artifact', async () => 
 
     res = await fetch(`${origin}/api/state/shared-state/checklist?token=${encodeURIComponent(token)}`);
     assert.equal(res.status, 404);
+  });
+});
+
+test('state API allows short-share cookie CRUD for the matching artifact', async () => {
+  const share = createShare('short-state', '24h', { allowPermanent: false });
+
+  await withServer(authConfig(), async ({ origin }) => {
+    const redirect = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
+    assert.equal(redirect.status, 302);
+    assert.equal(redirect.headers.get('location'), '/short-state');
+    assert.doesNotMatch(redirect.headers.get('location'), /token=/);
+    const cookies = cookieHeader(redirect.headers.get('set-cookie'));
+
+    let res = await fetch(`${origin}/api/state/short-state`, {
+      headers: { Cookie: cookies },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.deepEqual(await res.json(), { ok: true, state: {} });
+
+    res = await fetch(`${origin}/api/state/short-state/checklist`, {
+      method: 'PUT',
+      headers: sameOriginHeaders(origin, { Cookie: cookies }),
+      body: JSON.stringify({ value: { done: true } }),
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ok: true, key: 'checklist', value: { done: true } });
+
+    res = await fetch(`${origin}/api/state/short-state/checklist`, {
+      headers: { Cookie: cookies },
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ok: true, key: 'checklist', value: { done: true } });
   });
 });
 


### PR DESCRIPTION
Closes #40.\n\n## Summary\n- Add a reserved short share route, /s/:tokenId, that regenerates the existing HMAC token from shares.json metadata and redirects to the long token URL.\n- Make POST /api/share return the short URL as url/shortUrl while retaining longUrl for compatibility/debugging.\n- Let auth middleware pass valid short share paths through to the redirect route.\n- Add share API coverage for default short URLs, redirect behavior, and auth middleware pass-through.\n\n## Tests\n- npm test -- --test-name-pattern 'share|auth'\n- npm test