### PR TITLE
fix: trust loopback proxy for pages rate limiting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ async function main() {
 
   // Create Express app
   const app = express();
+  app.set('trust proxy', config.proxy?.trust ?? 'loopback');
 
   // Security headers
   app.use(securityHeaders());

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -43,6 +43,9 @@ export const DEFAULT_CONFIG = {
     windowMs: 60000,
     max: 60,
   },
+  proxy: {
+    trust: 'loopback',
+  },
   sharing: {
     enabled: true,
     allowPermanent: false,

--- a/test/rate-limit.test.js
+++ b/test/rate-limit.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import express from 'express';
+import { createRateLimiter } from '../src/security/rateLimit.js';
+
+async function withServer(fn) {
+  const app = express();
+  app.set('trust proxy', ['loopback', '100.64.0.23']);
+  app.use(createRateLimiter({
+    windowMs: 60_000,
+    max: 1,
+    message: { error: 'limited' },
+  }));
+  app.get('/probe', (req, res) => {
+    res.json({ ip: req.ip });
+  });
+
+  const server = await new Promise(resolve => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  const port = server.address().port;
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+test('rate limiter keys requests by forwarded client IP from trusted proxy chain', async () => {
+  await withServer(async (baseUrl) => {
+    const firstClient = await fetch(`${baseUrl}/probe`, {
+      headers: { 'X-Forwarded-For': '203.0.113.10, 100.64.0.23' },
+    });
+    assert.equal(firstClient.status, 200);
+    assert.equal((await firstClient.json()).ip, '203.0.113.10');
+
+    const secondClient = await fetch(`${baseUrl}/probe`, {
+      headers: { 'X-Forwarded-For': '203.0.113.11, 100.64.0.23' },
+    });
+    assert.equal(secondClient.status, 200);
+    assert.equal((await secondClient.json()).ip, '203.0.113.11');
+
+    const firstClientAgain = await fetch(`${baseUrl}/probe`, {
+      headers: { 'X-Forwarded-For': '203.0.113.10, 100.64.0.23' },
+    });
+    assert.equal(firstClientAgain.status, 429);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #45.

`zylos-pages` runs behind local Caddy (`/pages/*` -> `localhost:3462`) and receives `X-Forwarded-For`, but Express previously kept `trust proxy=false`. `express-rate-limit` therefore emitted `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` and could key proxied traffic by a proxy hop instead of the real client IP.

This PR:
- sets Express `trust proxy` from config, defaulting to `loopback`
- keeps the trust boundary configurable instead of using broad `true`
- adds a regression test for the real two-hop shape: `X-Forwarded-For: <client>, 100.64.0.23`, with trusted proxies `['loopback', '100.64.0.23']`

## Important deployment note

For zylos01 production, code alone silences the warning with the default `loopback`, but real-client rate-limit keying also needs the local preserved config to include the Springboard hop:

```json
"proxy": {
  "trust": ["loopback", "100.64.0.23"]
}
```

Reason: Caddy may append the immediate Springboard/Tailscale hop to `X-Forwarded-For`; trusting only loopback would make Express resolve `req.ip` as `100.64.0.23` rather than the browser/crawler client IP.

## Verification

- `node --test test/rate-limit.test.js`
- `npm test` (84/84)

## Deployment verification

After merge/deploy/config update/restart:
- make a proxied Pages request
- verify `components/pages/logs/error.log` does not get a new `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`
- verify request logs that use `req.ip` show the real client IP, not `100.64.0.23`
