### PR TITLE
Fix share editable flag not working in WeChat WebView

### DIFF
--- a/assets/attachments.js
+++ b/assets/attachments.js
@@ -56,7 +56,8 @@
 
   function canEditAttachments() {
     if (!isShareView()) return true;
-    return window.__PAGES_SHARE_EDITABLE === true;
+    return window.__PAGES_SHARE_EDITABLE === true
+      || document.documentElement.dataset.shareEditable === 'true';
   }
 
   function attachmentUrl(fileUrl) {

--- a/src/routes/pages.js
+++ b/src/routes/pages.js
@@ -9,6 +9,8 @@ import { logger } from '../utils/logger.js';
 import { browserBaseFromRequest, browserPath } from '../lib/browser-base.js';
 import { HTML_ARTIFACT_CSP } from '../security/headers.js';
 
+const ASSET_VERSION = Date.now();
+
 function redirectCleanExtension(req, res, browserBase, rawSlug, extension) {
   const clean = rawSlug.replace(new RegExp(`\\.${extension}$`, 'i'), '');
   const queryIndex = req.url.indexOf('?');
@@ -53,30 +55,43 @@ export function pageRoute(config) {
       if (isHtmlArtifact && (req.query.raw === '1' || isShareViewer)) {
         res.setHeader('Content-Security-Policy', HTML_ARTIFACT_CSP);
         res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-        const clientEtag = req.headers['if-none-match'];
-        if (clientEtag && clientEtag === result.etag) {
-          logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: 'html-raw' });
-          return res.status(304).end();
+        if (!isShareViewer) {
+          const clientEtag = req.headers['if-none-match'];
+          if (clientEtag && clientEtag === result.etag) {
+            logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: 'auth', type: 'html-raw' });
+            return res.status(304).end();
+          }
+          res.setHeader('ETag', result.etag);
+          res.setHeader('Cache-Control', 'public, max-age=60');
+        } else {
+          res.setHeader('Cache-Control', 'no-store');
         }
-        res.setHeader('ETag', result.etag);
-        res.setHeader('Cache-Control', isShareViewer ? 'no-store' : 'public, max-age=60');
         res.setHeader('Content-Type', 'text/html; charset=utf-8');
         logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: 'html-raw' });
         const baseTag = `<script>window.__PAGES_BASE=${JSON.stringify(browserBase)};window.__PAGES_VIEWER=${JSON.stringify(isShareViewer ? 'share' : 'auth')};window.__PAGES_SHARE_EDITABLE=${shareCanWriteAttachments ? 'true' : 'false'};</script>`;
-        const injected = result.html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
-        return res.send(injected !== result.html ? injected : baseTag + result.html);
+        let injected = result.html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
+        if (injected === result.html) injected = baseTag + result.html;
+        const viewerAttr = isShareViewer ? ` data-viewer="share"` : '';
+        const editableAttr = shareCanWriteAttachments ? ` data-share-editable="true"` : '';
+        injected = injected.replace(/<html([^>]*)>/i, `<html$1${viewerAttr}${editableAttr}>`);
+        injected = injected.replace(/src="([^"?]*_assets\/[^"?]+)"/g, `src="$1?v=${ASSET_VERSION}"`);
+        return res.send(injected);
       }
 
-      // ETag / 304 handling
+      // ETag / 304 handling — skip for share viewers because post-cache
+      // injections (editable flag, viewer attr) are not reflected in the ETag.
       const wrapperEtag = isHtmlArtifact ? `"${result.etag.replace(/"/g, '')}-wrapped"` : result.etag;
-      const clientEtag = req.headers['if-none-match'];
-      if (clientEtag && clientEtag === wrapperEtag) {
-        logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: result.type });
-        return res.status(304).end();
+      if (!isShareViewer) {
+        const clientEtag = req.headers['if-none-match'];
+        if (clientEtag && clientEtag === wrapperEtag) {
+          logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: 'auth', type: result.type });
+          return res.status(304).end();
+        }
+        res.setHeader('ETag', wrapperEtag);
+        res.setHeader('Cache-Control', 'public, max-age=60');
+      } else {
+        res.setHeader('Cache-Control', 'no-store');
       }
-
-      res.setHeader('ETag', wrapperEtag);
-      res.setHeader('Cache-Control', isShareViewer ? 'no-store' : 'public, max-age=60');
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
 
       if (isHtmlArtifact) {

--- a/src/templates/pageTemplate.js
+++ b/src/templates/pageTemplate.js
@@ -211,7 +211,8 @@ export function htmlArtifactTemplate({ title, baseUrl, slug, iframeSrc }) {
 export function injectShareViewer(html, options = {}) {
   const editable = options.canWriteAttachments === true;
   const viewerScript = `<script>window.__PAGES_VIEWER="share";window.__PAGES_SHARE_EDITABLE=${editable ? 'true' : 'false'};</script>`;
-  let injected = html.replace('<html lang="en">', '<html lang="en" data-viewer="share">');
+  const editableAttr = editable ? ' data-share-editable="true"' : '';
+  let injected = html.replace('<html lang="en">', `<html lang="en" data-viewer="share"${editableAttr}>`);
   injected = injected.replace(/<head([^>]*)>/i, `<head$1>${viewerScript}`);
   return injected !== html ? injected : viewerScript + html;
 }


### PR DESCRIPTION
## Summary

- **ETag 304 stale cache**: Share viewers got 304 responses with old cached HTML that lacked the editable flag, because the content ETag doesn't reflect post-cache injections. Fix: skip ETag 304 for share viewers (they already use `Cache-Control: no-store`).
- **Immutable JS cache**: Static HTML artifacts reference `attachments.js` without a version query, served with `max-age=86400, immutable`. WeChat cached the old version without the `data-share-editable` attribute fallback. Fix: server rewrites `_assets/` script URLs to append `?v=` cache buster.
- **Missing `data-share-editable` in `injectShareViewer`**: The template helper only added `data-viewer="share"` but not the editable attribute on the `<html>` tag. Fix: add the attribute when `canWriteAttachments` is true.
- **Client fallback**: `attachments.js` now checks `document.documentElement.dataset.shareEditable` as a fallback for environments (WeChat X5) that block inline scripts.

## Test plan

- [x] Verified fix live in WeChat WebView — upload button now visible on editable share links
- [x] Verified `curl` response includes both `data-share-editable="true"` and `__PAGES_SHARE_EDITABLE=true`
- [x] Verified share viewers always get 200 (not stale 304) even with matching ETag
- [x] Verified authenticated users still get ETag-based 304 caching
- [x] Verified `attachments.js` URL includes `?v=` version query in served HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)