### PR TITLE
feat: add HTML report template library

### DIFF
--- a/references/html-rendering.md
+++ b/references/html-rendering.md
@@ -1,0 +1,158 @@
+# HTML Rendering in Pages
+
+Pages supports two rendering modes: **Markdown** and **HTML**. The mode is determined by file extension.
+
+## Rendering Modes
+
+| | Markdown (`.md`) | HTML (`.html`) |
+|---|---|---|
+| **Rendering** | Converted to styled HTML with code highlighting, ToC, theme toggle | Served as-is inside an iframe wrapper |
+| **Styling** | Pages applies its own CSS (style.css) | Author controls all CSS |
+| **Navigation** | Integrated into page layout with sidebar | Wrapped in an iframe; sidebar available on outer frame |
+| **Use when** | Text-heavy content, reports, documentation | Custom layouts, dashboards, interactive pages, complex visual designs |
+
+## File Placement
+
+Both file types go in the same content directory:
+
+```
+~/zylos/http/public/pages/
+├── proposals/
+│   ├── my-proposal.md          → /pages/proposals/my-proposal
+│   └── backup-strategy.html    → /pages/proposals/backup-strategy
+├── daily-digest/
+│   └── 2026-06-23-morning.md   → /pages/daily-digest/2026-06-23-morning
+└── welcome.md                  → /pages/welcome
+```
+
+The file extension is stripped from the URL. A `.html` file and a `.md` file with the same base name would conflict — avoid this.
+
+## When to Use Each Mode
+
+### Use Markdown when:
+- Content is primarily text with headings, lists, tables, code blocks
+- You want consistent styling with automatic dark/light theme
+- Standard report format (Lark digests, research summaries, meeting notes)
+- Quick publishing — just write and drop the file
+
+### Use HTML when:
+- Layout needs go beyond what Markdown supports (multi-column, cards, grids)
+- Custom CSS is essential to the content (visual comparisons, styled dashboards)
+- Interactive elements are needed (collapsible sections, tabs, custom JS)
+- Precise control over typography and spacing is required
+- The document is a designed artifact, not just text
+
+## HTML Artifact Behavior
+
+HTML files are rendered differently from Markdown:
+
+1. **Iframe isolation**: The HTML content loads inside an iframe. This gives the author full CSS control without conflicting with Pages' own styles.
+2. **CSP**: HTML artifacts have a separate Content-Security-Policy (`HTML_ARTIFACT_CSP`) — inline styles are allowed, inline scripts are not.
+3. **Raw mode**: Append `?raw=1` to serve the HTML directly without the iframe wrapper.
+4. **Sharing**: Shared HTML artifacts are served directly (no iframe) since they are complete page designs.
+
+## Writing HTML Artifacts
+
+### Minimal structure
+
+```html
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Report Title</title>
+  <style>
+    /* All CSS goes here — inline styles are allowed in HTML artifacts */
+  </style>
+</head>
+<body>
+  <h1>Report Title</h1>
+  <!-- content -->
+</body>
+</html>
+```
+
+### Best practices
+
+- **Set `<title>`**: Pages extracts it for the navigation sidebar and browser tab.
+- **Include viewport meta**: Ensures responsive behavior on mobile.
+- **Use `lang` attribute**: Set `zh-CN` for Chinese content, `en` for English, to get correct CJK line-breaking and hyphenation.
+- **No inline `<script>` tags**: CSP blocks them. Use `<style>` for CSS (allowed) or reference external scripts via `_assets/`.
+- **Self-contained CSS**: Put all styles in a `<style>` block. No external CSS dependencies except Google Fonts.
+- **Dark mode support**: Use `prefers-color-scheme` media query or CSS custom properties with a toggle.
+
+### Dark mode pattern
+
+```css
+:root {
+  --bg: #ffffff;
+  --text: #1a1a1a;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --card-bg: #f9fafb;
+  --accent: #2563eb;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111827;
+    --text: #f3f4f6;
+    --muted: #9ca3af;
+    --border: #374151;
+    --card-bg: #1f2937;
+    --accent: #60a5fa;
+  }
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+```
+
+### CJK typography
+
+```css
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+  line-height: 1.8;  /* wider line-height for CJK readability */
+}
+```
+
+### Responsive layout
+
+```css
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 1rem;
+  }
+}
+```
+
+## Using Templates
+
+Templates are pre-designed HTML files stored in `templates/html/` in the zylos-pages repo. To use a template:
+
+1. Pick the template that matches your content type (see `templates/html/README.md`)
+2. Copy its HTML structure
+3. Replace placeholder content with your data
+4. Save as `.html` in the pages content directory
+
+Templates follow a shared CSS variable system so colors, fonts, and spacing are consistent across all report types.
+
+## Existing HTML Artifacts
+
+Examples of HTML artifacts already in use:
+
+| File | Type | Notable features |
+|------|------|-----------------|
+| `proposals/dgx-spark-backup-strategy.html` | Technical proposal | Two-column desktop layout, responsive, data classification table |
+| `renovation-checklist.html` | Interactive checklist | Collapsible phases, attachment blocks, editable via share links |

--- a/references/html-rendering.md
+++ b/references/html-rendering.md
@@ -47,7 +47,7 @@ The file extension is stripped from the URL. A `.html` file and a `.md` file wit
 HTML files are rendered differently from Markdown:
 
 1. **Iframe isolation**: The HTML content loads inside an iframe. This gives the author full CSS control without conflicting with Pages' own styles.
-2. **CSP**: HTML artifacts have a separate Content-Security-Policy (`HTML_ARTIFACT_CSP`) — inline styles are allowed, inline scripts are not.
+2. **CSP**: HTML artifacts have a separate Content-Security-Policy (`HTML_ARTIFACT_CSP`). Current runtime policy allows inline styles and inline scripts, but only loads scripts/styles/fonts from the same origin.
 3. **Raw mode**: Append `?raw=1` to serve the HTML directly without the iframe wrapper.
 4. **Sharing**: Shared HTML artifacts are served directly (no iframe) since they are complete page designs.
 
@@ -78,8 +78,8 @@ HTML files are rendered differently from Markdown:
 - **Set `<title>`**: Pages extracts it for the navigation sidebar and browser tab.
 - **Include viewport meta**: Ensures responsive behavior on mobile.
 - **Use `lang` attribute**: Set `zh-CN` for Chinese content, `en` for English, to get correct CJK line-breaking and hyphenation.
-- **No inline `<script>` tags**: CSP blocks them. Use `<style>` for CSS (allowed) or reference external scripts via `_assets/`.
-- **Self-contained CSS**: Put all styles in a `<style>` block. No external CSS dependencies except Google Fonts.
+- **Prefer no inline `<script>` tags**: The current HTML artifact CSP allows inline scripts, but external JS under `_assets/` is easier to review and reuse. Avoid remote scripts.
+- **Self-contained CSS**: Put all styles in a `<style>` block. Do not depend on external CSS or font hosts; the current CSP does not allow Google Fonts.
 - **Dark mode support**: Use `prefers-color-scheme` media query or CSS custom properties with a toggle.
 
 ### Dark mode pattern

--- a/templates/html/README.md
+++ b/templates/html/README.md
@@ -1,0 +1,54 @@
+# HTML Report Templates
+
+Pre-designed templates for generating styled HTML reports. Each template is standalone: copy the HTML, replace `{{PLACEHOLDER}}` values with your content, and save as `.html` in the pages content directory.
+
+The layouts are adapted from common open-source report patterns: executive summaries, comparison matrices, status banners, metric cards, and interview evaluation grids. Do not paste third-party HTML/CSS directly into generated reports unless the license has been checked.
+
+## Available Templates
+
+| Template | Use Case | Accent Color |
+|----------|----------|-------------|
+| `research-report.html` | Research reports, deep analysis, investigation findings | Blue |
+| `technical-proposal.html` | Technical proposals, architecture documents, design specs | Purple |
+| `comparison.html` | A vs B comparisons, competitive analysis, feature matrices | Teal |
+| `evaluation.html` | Interview evaluations, candidate assessments, review reports | Teal-green |
+
+## Shared Design System
+
+All templates share a common design token system defined in `base.css`:
+
+- **Typography**: System font stack with CJK support (Noto Sans SC, PingFang SC, Microsoft YaHei)
+- **Colors**: Semantic tokens (`--bg`, `--text`, `--accent`, `--success`, `--warning`, `--error`)
+- **Dark mode**: Automatic via `prefers-color-scheme: dark`
+- **Spacing**: 4px base grid (`--space-1` through `--space-16`)
+- **Responsive**: Mobile-first with 640px breakpoint
+- **Print**: Clean print stylesheet included
+
+Each template embeds the tokens inline (no external dependency). `base.css` is the canonical reference — when updating tokens, propagate to all templates.
+
+## Usage
+
+### For agents
+
+When generating an HTML report, pick the matching template and replace placeholders:
+
+```
+1. Read the template file
+2. Replace all {{PLACEHOLDER}} values with actual content
+3. Add/remove sections as needed (templates are starting points, not rigid)
+4. Write to ~/zylos/http/public/pages/<path>.html
+```
+
+### Customizing
+
+- **Add sections**: Copy an existing `<section>` block and modify
+- **Change accent color**: Override `--accent`, `--accent-light`, `--accent-text` in `:root`
+- **Add components**: Use utility classes from base.css (`.card`, `.badge`, `.callout`, `.stat-grid`)
+
+## Design Principles
+
+1. **Content first** - templates maximize reading area, minimize chrome
+2. **Information density** - tables, score bars, and cards pack data efficiently
+3. **CJK-ready** - line-height 1.75, font stack with Chinese fallbacks
+4. **No dependencies** - everything in one HTML file, no build step
+5. **Progressive** - works without JS, dark mode via CSS media query

--- a/templates/html/base.css
+++ b/templates/html/base.css
@@ -1,0 +1,288 @@
+/*
+ * Shared design tokens for zylos-pages HTML templates.
+ * Import via <style> copy-paste — no build step, no external dependency.
+ *
+ * Token layers:
+ *   1. Primitives  — raw values (colors, sizes, fonts)
+ *   2. Semantic    — purpose-mapped tokens (--text, --bg, --accent)
+ *   3. Component   — template-specific overrides (kept in each template)
+ */
+
+/* ── Reset ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ── Light theme (default) ── */
+:root {
+  /* Typography */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-serif: Georgia, "Noto Serif SC", "Source Han Serif SC", serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  --font-size-base: 1rem;
+  --font-size-sm: 0.875rem;
+  --font-size-xs: 0.75rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+  --line-height: 1.75;
+  --line-height-tight: 1.3;
+
+  /* Spacing (4px base grid) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Border */
+  --radius: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+
+  /* Colors — semantic */
+  --bg: #ffffff;
+  --bg-alt: #f8f9fb;
+  --bg-card: #ffffff;
+  --text: #1f2937;
+  --text-secondary: #4b5563;
+  --text-muted: #9ca3af;
+  --border: #e5e7eb;
+  --border-strong: #d1d5db;
+  --accent: #2563eb;
+  --accent-light: #dbeafe;
+  --accent-text: #1d4ed8;
+  --success: #059669;
+  --success-light: #d1fae5;
+  --warning: #d97706;
+  --warning-light: #fef3c7;
+  --error: #dc2626;
+  --error-light: #fee2e2;
+  --info: #0891b2;
+  --info-light: #cffafe;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.07), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -4px rgba(0, 0, 0, 0.04);
+
+  /* Layout */
+  --content-width: 900px;
+  --content-width-wide: 1100px;
+}
+
+/* ── Dark theme ── */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --bg-alt: #1e293b;
+    --bg-card: #1e293b;
+    --text: #e2e8f0;
+    --text-secondary: #94a3b8;
+    --text-muted: #64748b;
+    --border: #334155;
+    --border-strong: #475569;
+    --accent: #60a5fa;
+    --accent-light: #1e3a5f;
+    --accent-text: #93bbfc;
+    --success: #34d399;
+    --success-light: #064e3b;
+    --warning: #fbbf24;
+    --warning-light: #451a03;
+    --error: #f87171;
+    --error-light: #450a0a;
+    --info: #22d3ee;
+    --info-light: #083344;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.3);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -4px rgba(0, 0, 0, 0.3);
+  }
+}
+
+/* ── Base typography ── */
+html { font-size: 16px; -webkit-text-size-adjust: 100%; }
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height);
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  line-height: var(--line-height-tight);
+  color: var(--text);
+  font-weight: 600;
+}
+
+h1 { font-size: var(--font-size-3xl); margin-bottom: var(--space-6); }
+h2 { font-size: var(--font-size-2xl); margin-top: var(--space-10); margin-bottom: var(--space-4); }
+h3 { font-size: var(--font-size-xl); margin-top: var(--space-8); margin-bottom: var(--space-3); }
+h4 { font-size: var(--font-size-lg); margin-top: var(--space-6); margin-bottom: var(--space-2); }
+
+p { margin-bottom: var(--space-4); }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--bg-alt);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
+
+pre {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  overflow-x: auto;
+  margin-bottom: var(--space-4);
+}
+pre code { background: none; border: none; padding: 0; }
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  background: var(--bg-alt);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  color: var(--text-secondary);
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-8) 0;
+}
+
+/* ── Tables ── */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--space-6);
+  font-size: var(--font-size-sm);
+}
+th, td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+th {
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+tr:hover td { background: var(--bg-alt); }
+
+/* ── Lists ── */
+ul, ol { padding-left: var(--space-6); margin-bottom: var(--space-4); }
+li { margin-bottom: var(--space-1); }
+li::marker { color: var(--text-muted); }
+
+/* ── Utility classes ── */
+.container { max-width: var(--content-width); margin: 0 auto; padding: var(--space-8) var(--space-6); }
+.container-wide { max-width: var(--content-width-wide); margin: 0 auto; padding: var(--space-8) var(--space-6); }
+.text-sm { font-size: var(--font-size-sm); }
+.text-xs { font-size: var(--font-size-xs); }
+.text-muted { color: var(--text-muted); }
+.text-secondary { color: var(--text-secondary); }
+.text-accent { color: var(--accent); }
+.text-center { text-align: center; }
+.font-mono { font-family: var(--font-mono); }
+.mt-0 { margin-top: 0; }
+.mb-0 { margin-bottom: 0; }
+
+/* ── Cards ── */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+}
+
+/* ── Badges / Tags ── */
+.badge {
+  display: inline-block;
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  padding: 0.15em 0.5em;
+  border-radius: 9999px;
+  background: var(--accent-light);
+  color: var(--accent-text);
+}
+.badge-success { background: var(--success-light); color: var(--success); }
+.badge-warning { background: var(--warning-light); color: var(--warning); }
+.badge-error { background: var(--error-light); color: var(--error); }
+
+/* ── Stat cards (for dashboards) ── */
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+.stat-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  text-align: center;
+}
+.stat-value {
+  font-size: var(--font-size-3xl);
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1.2;
+}
+.stat-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+}
+
+/* ── Callout boxes ── */
+.callout {
+  padding: var(--space-4);
+  border-radius: var(--radius);
+  margin-bottom: var(--space-4);
+  border-left: 4px solid;
+}
+.callout-info { background: var(--info-light); border-color: var(--info); }
+.callout-success { background: var(--success-light); border-color: var(--success); }
+.callout-warning { background: var(--warning-light); border-color: var(--warning); }
+.callout-error { background: var(--error-light); border-color: var(--error); }
+
+/* ── Print ── */
+@media print {
+  body { background: white; color: black; font-size: 11pt; }
+  .container { max-width: none; padding: 0; }
+  h1, h2, h3 { page-break-after: avoid; }
+  table, pre, blockquote { page-break-inside: avoid; }
+  a { color: inherit; text-decoration: underline; }
+  .no-print { display: none !important; }
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  :root { --font-size-base: 0.9375rem; }
+  .container, .container-wide { padding: var(--space-4) var(--space-4); }
+  h1 { font-size: var(--font-size-2xl); }
+  h2 { font-size: var(--font-size-xl); }
+  table { font-size: var(--font-size-xs); }
+  .stat-grid { grid-template-columns: repeat(2, 1fr); }
+}

--- a/templates/html/comparison.html
+++ b/templates/html/comparison.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{TITLE}}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --font-size-base: 1rem; --font-size-sm: 0.875rem; --font-size-xs: 0.75rem;
+      --font-size-lg: 1.125rem; --font-size-xl: 1.25rem; --font-size-2xl: 1.5rem; --font-size-3xl: 1.875rem;
+      --line-height: 1.75; --line-height-tight: 1.3;
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+      --space-6: 1.5rem; --space-8: 2rem; --space-10: 2.5rem; --space-12: 3rem;
+      --radius: 0.375rem; --radius-lg: 0.5rem;
+      --bg: #ffffff; --bg-alt: #f8f9fb; --bg-card: #ffffff;
+      --text: #1f2937; --text-secondary: #4b5563; --text-muted: #9ca3af;
+      --border: #e5e7eb; --border-strong: #d1d5db;
+      --accent: #0891b2; --accent-light: #cffafe; --accent-text: #0e7490;
+      --option-a: #2563eb; --option-a-light: #dbeafe;
+      --option-b: #7c3aed; --option-b-light: #ede9fe;
+      --success: #059669; --success-light: #d1fae5;
+      --warning: #d97706; --warning-light: #fef3c7;
+      --error: #dc2626; --error-light: #fee2e2;
+      --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+      --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
+      --content-width: 1000px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a; --bg-alt: #1e293b; --bg-card: #1e293b;
+        --text: #e2e8f0; --text-secondary: #94a3b8; --text-muted: #64748b;
+        --border: #334155; --border-strong: #475569;
+        --accent: #22d3ee; --accent-light: #083344; --accent-text: #67e8f9;
+        --option-a: #60a5fa; --option-a-light: #1e3a5f;
+        --option-b: #a78bfa; --option-b-light: #2e1065;
+        --success: #34d399; --success-light: #064e3b;
+        --warning: #fbbf24; --warning-light: #451a03;
+        --error: #f87171; --error-light: #450a0a;
+        --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+      }
+    }
+    html { font-size: 16px; }
+    body { font-family: var(--font-sans); font-size: var(--font-size-base); line-height: var(--line-height); color: var(--text); background: var(--bg); -webkit-font-smoothing: antialiased; }
+    h1, h2, h3, h4 { line-height: var(--line-height-tight); font-weight: 600; }
+    a { color: var(--accent); text-decoration: none; }
+    code { font-family: var(--font-mono); font-size: 0.9em; background: var(--bg-alt); padding: 0.15em 0.35em; border-radius: 3px; border: 1px solid var(--border); }
+    table { width: 100%; border-collapse: collapse; margin-bottom: var(--space-6); font-size: var(--font-size-sm); }
+    th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border); }
+    th { font-weight: 600; color: var(--text-secondary); font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+    ul, ol { padding-left: var(--space-6); margin-bottom: var(--space-4); }
+    li { margin-bottom: var(--space-2); }
+    p { margin-bottom: var(--space-4); }
+    hr { border: none; border-top: 1px solid var(--border); margin: var(--space-8) 0; }
+
+    /* ── Comparison specific ── */
+    .comparison { max-width: var(--content-width); margin: 0 auto; padding: var(--space-8) var(--space-6); }
+
+    .comparison-header {
+      text-align: center;
+      margin-bottom: var(--space-8);
+    }
+    .comparison-header h1 { font-size: var(--font-size-3xl); margin-bottom: var(--space-3); }
+    .comparison-header .subtitle { color: var(--text-secondary); font-size: var(--font-size-lg); margin-bottom: var(--space-4); }
+    .comparison-header .meta { font-size: var(--font-size-sm); color: var(--text-muted); }
+
+    .vs-banner {
+      display: flex; align-items: center; justify-content: center; gap: var(--space-6);
+      padding: var(--space-6);
+      margin-bottom: var(--space-8);
+    }
+    .vs-option {
+      flex: 1; text-align: center; padding: var(--space-4);
+      border-radius: var(--radius-lg); font-weight: 600; font-size: var(--font-size-xl);
+    }
+    .vs-option-a { background: var(--option-a-light); color: var(--option-a); border: 2px solid var(--option-a); }
+    .vs-option-b { background: var(--option-b-light); color: var(--option-b); border: 2px solid var(--option-b); }
+    .vs-divider { font-size: var(--font-size-2xl); font-weight: 700; color: var(--text-muted); }
+
+    .dimension-section { margin-bottom: var(--space-8); }
+    .dimension-section h2 {
+      font-size: var(--font-size-xl); margin-bottom: var(--space-4);
+      padding-bottom: var(--space-2); border-bottom: 1px solid var(--border);
+    }
+
+    .comparison-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4);
+      margin-bottom: var(--space-4);
+    }
+    .comparison-card {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-4);
+      box-shadow: var(--shadow-sm);
+    }
+    .comparison-card.option-a { border-top: 3px solid var(--option-a); }
+    .comparison-card.option-b { border-top: 3px solid var(--option-b); }
+    .comparison-card h4 { font-size: var(--font-size-sm); color: var(--text-muted); margin-bottom: var(--space-2); text-transform: uppercase; letter-spacing: 0.05em; }
+
+    .score-row {
+      display: flex; align-items: center; gap: var(--space-3);
+      padding: var(--space-3) 0;
+    }
+    .score-label { flex: 0 0 160px; font-size: var(--font-size-sm); color: var(--text-secondary); }
+    .score-bar-track { flex: 1; height: 8px; background: var(--bg-alt); border-radius: 4px; overflow: hidden; }
+    .score-bar { height: 100%; border-radius: 4px; transition: width 0.3s; }
+    .score-bar.a { background: var(--option-a); }
+    .score-bar.b { background: var(--option-b); }
+    .score-value { flex: 0 0 40px; text-align: right; font-size: var(--font-size-sm); font-weight: 600; }
+
+    .feature-table td:nth-child(2),
+    .feature-table td:nth-child(3) { text-align: center; }
+    .feature-table th:nth-child(2) { color: var(--option-a); }
+    .feature-table th:nth-child(3) { color: var(--option-b); }
+    .check { color: var(--success); font-weight: 700; }
+    .cross { color: var(--error); }
+    .partial { color: var(--warning); }
+
+    .verdict {
+      background: var(--accent-light); border: 2px solid var(--accent);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-top: var(--space-8); text-align: center;
+    }
+    .verdict h2 { color: var(--accent-text); margin-top: 0; margin-bottom: var(--space-3); }
+
+    .comparison-footer {
+      margin-top: var(--space-12); padding-top: var(--space-6);
+      border-top: 1px solid var(--border);
+      font-size: var(--font-size-sm); color: var(--text-muted); text-align: center;
+    }
+
+    @media print {
+      body { background: white; color: black; }
+      .comparison { max-width: none; padding: 0; }
+      .comparison-grid { grid-template-columns: 1fr 1fr; }
+    }
+    @media (max-width: 640px) {
+      .comparison { padding: var(--space-4); }
+      .vs-banner { flex-direction: column; gap: var(--space-3); }
+      .comparison-grid { grid-template-columns: 1fr; }
+      .score-label { flex: 0 0 100px; }
+      h1 { font-size: var(--font-size-2xl); }
+    }
+  </style>
+</head>
+<body>
+  <div class="comparison">
+
+    <header class="comparison-header">
+      <h1>{{TITLE}}</h1>
+      <p class="subtitle">{{SUBTITLE}}</p>
+      <p class="meta">{{DATE}} · {{AUTHOR}}</p>
+    </header>
+
+    <div class="vs-banner">
+      <div class="vs-option vs-option-a">{{OPTION_A}}</div>
+      <div class="vs-divider">VS</div>
+      <div class="vs-option vs-option-b">{{OPTION_B}}</div>
+    </div>
+
+    <section class="dimension-section">
+      <h2>Overall Scores</h2>
+      <div class="score-row">
+        <span class="score-label">{{DIMENSION_1}}</span>
+        <div class="score-bar-track"><div class="score-bar a" style="width: {{SCORE_A1}}%"></div></div>
+        <span class="score-value">{{SCORE_A1}}</span>
+        <div class="score-bar-track"><div class="score-bar b" style="width: {{SCORE_B1}}%"></div></div>
+        <span class="score-value">{{SCORE_B1}}</span>
+      </div>
+      <div class="score-row">
+        <span class="score-label">{{DIMENSION_2}}</span>
+        <div class="score-bar-track"><div class="score-bar a" style="width: {{SCORE_A2}}%"></div></div>
+        <span class="score-value">{{SCORE_A2}}</span>
+        <div class="score-bar-track"><div class="score-bar b" style="width: {{SCORE_B2}}%"></div></div>
+        <span class="score-value">{{SCORE_B2}}</span>
+      </div>
+    </section>
+
+    <section class="dimension-section">
+      <h2>Feature Comparison</h2>
+      <table class="feature-table">
+        <thead>
+          <tr><th>Feature</th><th>{{OPTION_A}}</th><th>{{OPTION_B}}</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>{{FEATURE_1}}</td><td class="check">Yes</td><td class="check">Yes</td></tr>
+          <tr><td>{{FEATURE_2}}</td><td class="check">Yes</td><td class="cross">No</td></tr>
+          <tr><td>{{FEATURE_3}}</td><td class="partial">Partial</td><td class="check">Yes</td></tr>
+          <tr><td>{{FEATURE_4}}</td><td class="cross">No</td><td class="check">Yes</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="dimension-section">
+      <h2>Detailed Analysis</h2>
+      <div class="comparison-grid">
+        <div class="comparison-card option-a">
+          <h4>{{OPTION_A}}</h4>
+          <p>{{DETAIL_A}}</p>
+        </div>
+        <div class="comparison-card option-b">
+          <h4>{{OPTION_B}}</h4>
+          <p>{{DETAIL_B}}</p>
+        </div>
+      </div>
+    </section>
+
+    <div class="verdict">
+      <h2>Verdict</h2>
+      <p>{{VERDICT_TEXT}}</p>
+    </div>
+
+    <footer class="comparison-footer">
+      Generated by Zylos &mdash; {{DATE}}
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/templates/html/evaluation.html
+++ b/templates/html/evaluation.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{TITLE}}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --font-size-base: 1rem; --font-size-sm: 0.875rem; --font-size-xs: 0.75rem;
+      --font-size-lg: 1.125rem; --font-size-xl: 1.25rem; --font-size-2xl: 1.5rem; --font-size-3xl: 1.875rem;
+      --line-height: 1.75; --line-height-tight: 1.3;
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+      --space-6: 1.5rem; --space-8: 2rem; --space-10: 2.5rem; --space-12: 3rem;
+      --radius: 0.375rem; --radius-lg: 0.5rem;
+      --bg: #ffffff; --bg-alt: #f8f9fb; --bg-card: #ffffff;
+      --text: #1f2937; --text-secondary: #4b5563; --text-muted: #9ca3af;
+      --border: #e5e7eb; --border-strong: #d1d5db;
+      --accent: #0d9488; --accent-light: #ccfbf1; --accent-text: #0f766e;
+      --success: #059669; --success-light: #d1fae5;
+      --warning: #d97706; --warning-light: #fef3c7;
+      --error: #dc2626; --error-light: #fee2e2;
+      --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+      --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
+      --content-width: 860px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a; --bg-alt: #1e293b; --bg-card: #1e293b;
+        --text: #e2e8f0; --text-secondary: #94a3b8; --text-muted: #64748b;
+        --border: #334155; --border-strong: #475569;
+        --accent: #2dd4bf; --accent-light: #042f2e; --accent-text: #5eead4;
+        --success: #34d399; --success-light: #064e3b;
+        --warning: #fbbf24; --warning-light: #451a03;
+        --error: #f87171; --error-light: #450a0a;
+        --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+      }
+    }
+    html { font-size: 16px; }
+    body { font-family: var(--font-sans); font-size: var(--font-size-base); line-height: var(--line-height); color: var(--text); background: var(--bg); -webkit-font-smoothing: antialiased; }
+    h1, h2, h3, h4 { line-height: var(--line-height-tight); font-weight: 600; }
+    a { color: var(--accent); text-decoration: none; }
+    code { font-family: var(--font-mono); font-size: 0.9em; background: var(--bg-alt); padding: 0.15em 0.35em; border-radius: 3px; border: 1px solid var(--border); }
+    table { width: 100%; border-collapse: collapse; margin-bottom: var(--space-6); font-size: var(--font-size-sm); }
+    th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border); }
+    th { font-weight: 600; color: var(--text-secondary); font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+    ul, ol { padding-left: var(--space-6); margin-bottom: var(--space-4); }
+    li { margin-bottom: var(--space-2); }
+    p { margin-bottom: var(--space-4); }
+    hr { border: none; border-top: 1px solid var(--border); margin: var(--space-8) 0; }
+
+    /* ── Evaluation specific ── */
+    .evaluation { max-width: var(--content-width); margin: 0 auto; padding: var(--space-8) var(--space-6); }
+
+    .eval-header { margin-bottom: var(--space-8); }
+    .eval-header h1 { font-size: var(--font-size-3xl); margin-bottom: var(--space-4); }
+
+    .candidate-card {
+      display: grid; grid-template-columns: auto 1fr;
+      gap: var(--space-4) var(--space-6);
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-6); box-shadow: var(--shadow-sm);
+    }
+    .candidate-avatar {
+      width: 80px; height: 80px; border-radius: 50%;
+      background: var(--accent-light); display: flex; align-items: center;
+      justify-content: center; font-size: var(--font-size-2xl);
+      font-weight: 700; color: var(--accent-text);
+    }
+    .candidate-info h2 { font-size: var(--font-size-xl); margin-bottom: var(--space-2); margin-top: 0; }
+    .candidate-details {
+      display: flex; flex-wrap: wrap; gap: var(--space-3);
+      font-size: var(--font-size-sm); color: var(--text-secondary);
+    }
+
+    .verdict-banner {
+      display: flex; align-items: center; gap: var(--space-4);
+      padding: var(--space-4) var(--space-6);
+      border-radius: var(--radius-lg); margin-bottom: var(--space-8);
+      font-weight: 600; font-size: var(--font-size-lg);
+    }
+    .verdict-pass { background: var(--success-light); border: 1px solid var(--success); color: var(--success); }
+    .verdict-fail { background: var(--error-light); border: 1px solid var(--error); color: var(--error); }
+    .verdict-hold { background: var(--warning-light); border: 1px solid var(--warning); color: var(--warning); }
+    .verdict-icon { font-size: var(--font-size-2xl); }
+
+    .score-overview {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: var(--space-4); margin-bottom: var(--space-8);
+    }
+    .score-item {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-4);
+      text-align: center;
+    }
+    .score-number { font-size: var(--font-size-2xl); font-weight: 700; }
+    .score-high { color: var(--success); }
+    .score-mid { color: var(--warning); }
+    .score-low { color: var(--error); }
+    .score-dim { font-size: var(--font-size-xs); color: var(--text-muted); margin-top: var(--space-1); text-transform: uppercase; letter-spacing: 0.05em; }
+
+    section { margin-bottom: var(--space-8); }
+    section h2 { font-size: var(--font-size-xl); margin-bottom: var(--space-4); padding-bottom: var(--space-2); border-bottom: 1px solid var(--border); }
+
+    .strength-item, .concern-item {
+      display: flex; gap: var(--space-3); margin-bottom: var(--space-3);
+      padding: var(--space-3) var(--space-4);
+      border-radius: var(--radius);
+    }
+    .strength-item { background: var(--success-light); }
+    .concern-item { background: var(--warning-light); }
+    .item-icon { flex-shrink: 0; font-size: var(--font-size-lg); }
+
+    .next-steps {
+      background: var(--bg-alt); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+    }
+    .next-steps h3 { margin-top: 0; margin-bottom: var(--space-4); }
+
+    .eval-footer {
+      margin-top: var(--space-12); padding-top: var(--space-6);
+      border-top: 1px solid var(--border);
+      font-size: var(--font-size-sm); color: var(--text-muted); text-align: center;
+    }
+
+    @media print {
+      body { background: white; color: black; }
+      .evaluation { max-width: none; padding: 0; }
+      .verdict-banner { border: 2px solid; }
+    }
+    @media (max-width: 640px) {
+      .evaluation { padding: var(--space-4); }
+      .candidate-card { grid-template-columns: 1fr; text-align: center; }
+      .candidate-avatar { margin: 0 auto; }
+      .candidate-details { justify-content: center; }
+      .score-overview { grid-template-columns: repeat(2, 1fr); }
+      h1 { font-size: var(--font-size-2xl); }
+    }
+  </style>
+</head>
+<body>
+  <div class="evaluation">
+
+    <header class="eval-header">
+      <h1>{{TITLE}}</h1>
+    </header>
+
+    <div class="candidate-card">
+      <div class="candidate-avatar">{{INITIALS}}</div>
+      <div class="candidate-info">
+        <h2>{{CANDIDATE_NAME}}</h2>
+        <div class="candidate-details">
+          <span>{{ROLE}}</span>
+          <span>·</span>
+          <span>{{DATE}}</span>
+          <span>·</span>
+          <span>{{INTERVIEWER}}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="verdict-banner verdict-pass">
+      <span class="verdict-icon">{{VERDICT_ICON}}</span>
+      <span>{{VERDICT}}: {{VERDICT_SUMMARY}}</span>
+    </div>
+
+    <div class="score-overview">
+      <div class="score-item">
+        <div class="score-number score-high">{{SCORE_1}}</div>
+        <div class="score-dim">{{DIM_1}}</div>
+      </div>
+      <div class="score-item">
+        <div class="score-number score-mid">{{SCORE_2}}</div>
+        <div class="score-dim">{{DIM_2}}</div>
+      </div>
+      <div class="score-item">
+        <div class="score-number score-high">{{SCORE_3}}</div>
+        <div class="score-dim">{{DIM_3}}</div>
+      </div>
+      <div class="score-item">
+        <div class="score-number score-low">{{SCORE_4}}</div>
+        <div class="score-dim">{{DIM_4}}</div>
+      </div>
+    </div>
+
+    <section>
+      <h2>Strengths</h2>
+      <div class="strength-item">
+        <span class="item-icon">+</span>
+        <div>
+          <strong>{{STRENGTH_1_TITLE}}</strong>
+          <p style="margin-bottom:0">{{STRENGTH_1_DETAIL}}</p>
+        </div>
+      </div>
+      <div class="strength-item">
+        <span class="item-icon">+</span>
+        <div>
+          <strong>{{STRENGTH_2_TITLE}}</strong>
+          <p style="margin-bottom:0">{{STRENGTH_2_DETAIL}}</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Concerns</h2>
+      <div class="concern-item">
+        <span class="item-icon">!</span>
+        <div>
+          <strong>{{CONCERN_1_TITLE}}</strong>
+          <p style="margin-bottom:0">{{CONCERN_1_DETAIL}}</p>
+        </div>
+      </div>
+      <div class="concern-item">
+        <span class="item-icon">!</span>
+        <div>
+          <strong>{{CONCERN_2_TITLE}}</strong>
+          <p style="margin-bottom:0">{{CONCERN_2_DETAIL}}</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Detailed Notes</h2>
+      <p>{{DETAILED_NOTES}}</p>
+    </section>
+
+    <div class="next-steps">
+      <h3>Next Steps</h3>
+      <ol>
+        <li>{{NEXT_STEP_1}}</li>
+        <li>{{NEXT_STEP_2}}</li>
+        <li>{{NEXT_STEP_3}}</li>
+      </ol>
+    </div>
+
+    <footer class="eval-footer">
+      Generated by Zylos &mdash; {{DATE}}
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/templates/html/research-report.html
+++ b/templates/html/research-report.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{TITLE}}</title>
+  <style>
+    /* ── Paste base.css tokens here, then add template-specific styles below ── */
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --font-size-base: 1rem; --font-size-sm: 0.875rem; --font-size-xs: 0.75rem;
+      --font-size-lg: 1.125rem; --font-size-xl: 1.25rem; --font-size-2xl: 1.5rem; --font-size-3xl: 1.875rem;
+      --line-height: 1.75; --line-height-tight: 1.3;
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+      --space-6: 1.5rem; --space-8: 2rem; --space-10: 2.5rem; --space-12: 3rem;
+      --radius: 0.375rem; --radius-lg: 0.5rem;
+      --bg: #ffffff; --bg-alt: #f8f9fb; --bg-card: #ffffff;
+      --text: #1f2937; --text-secondary: #4b5563; --text-muted: #9ca3af;
+      --border: #e5e7eb; --border-strong: #d1d5db;
+      --accent: #2563eb; --accent-light: #dbeafe; --accent-text: #1d4ed8;
+      --success: #059669; --success-light: #d1fae5;
+      --warning: #d97706; --warning-light: #fef3c7;
+      --error: #dc2626; --error-light: #fee2e2;
+      --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+      --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
+      --content-width: 860px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a; --bg-alt: #1e293b; --bg-card: #1e293b;
+        --text: #e2e8f0; --text-secondary: #94a3b8; --text-muted: #64748b;
+        --border: #334155; --border-strong: #475569;
+        --accent: #60a5fa; --accent-light: #1e3a5f; --accent-text: #93bbfc;
+        --success: #34d399; --success-light: #064e3b;
+        --warning: #fbbf24; --warning-light: #451a03;
+        --error: #f87171; --error-light: #450a0a;
+        --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+        --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4), 0 2px 4px -2px rgba(0,0,0,0.3);
+      }
+    }
+    html { font-size: 16px; }
+    body {
+      font-family: var(--font-sans); font-size: var(--font-size-base);
+      line-height: var(--line-height); color: var(--text); background: var(--bg);
+      -webkit-font-smoothing: antialiased;
+    }
+    h1, h2, h3, h4 { line-height: var(--line-height-tight); font-weight: 600; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--font-mono); font-size: 0.9em; background: var(--bg-alt); padding: 0.15em 0.35em; border-radius: 3px; border: 1px solid var(--border); }
+    pre { background: var(--bg-alt); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-4); overflow-x: auto; margin-bottom: var(--space-4); }
+    pre code { background: none; border: none; padding: 0; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: var(--space-6); font-size: var(--font-size-sm); }
+    th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border); }
+    th { font-weight: 600; color: var(--text-secondary); font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+    tr:hover td { background: var(--bg-alt); }
+    ul, ol { padding-left: var(--space-6); margin-bottom: var(--space-4); }
+    li { margin-bottom: var(--space-1); }
+    blockquote { border-left: 3px solid var(--accent); padding: var(--space-3) var(--space-4); margin: var(--space-4) 0; background: var(--bg-alt); border-radius: 0 var(--radius) var(--radius) 0; color: var(--text-secondary); }
+    hr { border: none; border-top: 1px solid var(--border); margin: var(--space-8) 0; }
+
+    /* ── Research Report specific ── */
+    .report { max-width: var(--content-width); margin: 0 auto; padding: var(--space-8) var(--space-6); }
+
+    .report-header {
+      border-bottom: 2px solid var(--accent);
+      padding-bottom: var(--space-6);
+      margin-bottom: var(--space-8);
+    }
+    .report-header h1 { font-size: var(--font-size-3xl); margin-bottom: var(--space-3); }
+    .report-meta {
+      display: flex; flex-wrap: wrap; gap: var(--space-4);
+      font-size: var(--font-size-sm); color: var(--text-muted);
+    }
+    .report-meta span { display: flex; align-items: center; gap: var(--space-1); }
+
+    .executive-summary {
+      background: var(--accent-light);
+      border: 1px solid var(--accent);
+      border-radius: var(--radius-lg);
+      padding: var(--space-6);
+      margin-bottom: var(--space-8);
+    }
+    .executive-summary h2 { font-size: var(--font-size-lg); margin-top: 0; margin-bottom: var(--space-3); color: var(--accent-text); }
+
+    .toc {
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: var(--space-4) var(--space-6);
+      margin-bottom: var(--space-8);
+    }
+    .toc h2 { font-size: var(--font-size-base); margin-top: 0; margin-bottom: var(--space-3); }
+    .toc ol { margin-bottom: 0; }
+    .toc li { margin-bottom: var(--space-2); }
+
+    section { margin-bottom: var(--space-10); }
+    section h2 { font-size: var(--font-size-2xl); padding-bottom: var(--space-2); border-bottom: 1px solid var(--border); }
+
+    .finding-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: var(--space-4) var(--space-6);
+      margin-bottom: var(--space-4);
+      box-shadow: var(--shadow-sm);
+    }
+    .finding-card h4 { margin-top: 0; margin-bottom: var(--space-2); }
+
+    .badge {
+      display: inline-block; font-size: var(--font-size-xs); font-weight: 500;
+      padding: 0.15em 0.5em; border-radius: 9999px;
+      background: var(--accent-light); color: var(--accent-text);
+    }
+    .badge-success { background: var(--success-light); color: var(--success); }
+    .badge-warning { background: var(--warning-light); color: var(--warning); }
+    .badge-error { background: var(--error-light); color: var(--error); }
+
+    .callout { padding: var(--space-4); border-radius: var(--radius); margin-bottom: var(--space-4); border-left: 4px solid; }
+    .callout-info { background: var(--bg-alt); border-color: var(--accent); }
+    .callout-warning { background: var(--warning-light); border-color: var(--warning); }
+
+    .report-footer {
+      margin-top: var(--space-12);
+      padding-top: var(--space-6);
+      border-top: 1px solid var(--border);
+      font-size: var(--font-size-sm);
+      color: var(--text-muted);
+      text-align: center;
+    }
+
+    @media print {
+      body { background: white; color: black; }
+      .report { max-width: none; padding: 0; }
+      .executive-summary { border: 1px solid #ccc; }
+      a { color: inherit; }
+    }
+    @media (max-width: 640px) {
+      .report { padding: var(--space-4); }
+      .report-meta { flex-direction: column; gap: var(--space-2); }
+      h1 { font-size: var(--font-size-2xl); }
+    }
+  </style>
+</head>
+<body>
+  <div class="report">
+
+    <header class="report-header">
+      <h1>{{TITLE}}</h1>
+      <div class="report-meta">
+        <span>{{DATE}}</span>
+        <span>{{AUTHOR}}</span>
+        <span>{{CATEGORY}}</span>
+      </div>
+    </header>
+
+    <div class="executive-summary">
+      <h2>Executive Summary</h2>
+      <p>{{SUMMARY}}</p>
+    </div>
+
+    <nav class="toc">
+      <h2>Table of Contents</h2>
+      <ol>
+        <li><a href="#background">Background</a></li>
+        <li><a href="#findings">Key Findings</a></li>
+        <li><a href="#analysis">Analysis</a></li>
+        <li><a href="#recommendations">Recommendations</a></li>
+      </ol>
+    </nav>
+
+    <section id="background">
+      <h2>1. Background</h2>
+      <p>{{BACKGROUND_CONTENT}}</p>
+    </section>
+
+    <section id="findings">
+      <h2>2. Key Findings</h2>
+
+      <div class="finding-card">
+        <h4>Finding 1 <span class="badge">{{SEVERITY}}</span></h4>
+        <p>{{FINDING_DESCRIPTION}}</p>
+      </div>
+
+      <div class="finding-card">
+        <h4>Finding 2 <span class="badge badge-warning">Medium</span></h4>
+        <p>{{FINDING_DESCRIPTION}}</p>
+      </div>
+    </section>
+
+    <section id="analysis">
+      <h2>3. Analysis</h2>
+      <p>{{ANALYSIS_CONTENT}}</p>
+
+      <div class="callout callout-info">
+        <strong>Note:</strong> {{CALLOUT_CONTENT}}
+      </div>
+    </section>
+
+    <section id="recommendations">
+      <h2>4. Recommendations</h2>
+      <ol>
+        <li>{{RECOMMENDATION_1}}</li>
+        <li>{{RECOMMENDATION_2}}</li>
+        <li>{{RECOMMENDATION_3}}</li>
+      </ol>
+    </section>
+
+    <footer class="report-footer">
+      Generated by Zylos &mdash; {{DATE}}
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/templates/html/technical-proposal.html
+++ b/templates/html/technical-proposal.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{TITLE}}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --font-size-base: 1rem; --font-size-sm: 0.875rem; --font-size-xs: 0.75rem;
+      --font-size-lg: 1.125rem; --font-size-xl: 1.25rem; --font-size-2xl: 1.5rem; --font-size-3xl: 1.875rem;
+      --line-height: 1.75; --line-height-tight: 1.3;
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+      --space-6: 1.5rem; --space-8: 2rem; --space-10: 2.5rem; --space-12: 3rem;
+      --radius: 0.375rem; --radius-lg: 0.5rem;
+      --bg: #ffffff; --bg-alt: #f8f9fb; --bg-card: #ffffff;
+      --text: #1f2937; --text-secondary: #4b5563; --text-muted: #9ca3af;
+      --border: #e5e7eb; --border-strong: #d1d5db;
+      --accent: #7c3aed; --accent-light: #ede9fe; --accent-text: #6d28d9;
+      --success: #059669; --success-light: #d1fae5;
+      --warning: #d97706; --warning-light: #fef3c7;
+      --error: #dc2626; --error-light: #fee2e2;
+      --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+      --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
+      --content-width: 900px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a; --bg-alt: #1e293b; --bg-card: #1e293b;
+        --text: #e2e8f0; --text-secondary: #94a3b8; --text-muted: #64748b;
+        --border: #334155; --border-strong: #475569;
+        --accent: #a78bfa; --accent-light: #2e1065; --accent-text: #c4b5fd;
+        --success: #34d399; --success-light: #064e3b;
+        --warning: #fbbf24; --warning-light: #451a03;
+        --error: #f87171; --error-light: #450a0a;
+        --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+        --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4), 0 2px 4px -2px rgba(0,0,0,0.3);
+      }
+    }
+    html { font-size: 16px; }
+    body { font-family: var(--font-sans); font-size: var(--font-size-base); line-height: var(--line-height); color: var(--text); background: var(--bg); -webkit-font-smoothing: antialiased; }
+    h1, h2, h3, h4 { line-height: var(--line-height-tight); font-weight: 600; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: var(--font-mono); font-size: 0.9em; background: var(--bg-alt); padding: 0.15em 0.35em; border-radius: 3px; border: 1px solid var(--border); }
+    pre { background: var(--bg-alt); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-4); overflow-x: auto; margin-bottom: var(--space-4); }
+    pre code { background: none; border: none; padding: 0; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: var(--space-6); font-size: var(--font-size-sm); }
+    th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border); }
+    th { font-weight: 600; color: var(--text-secondary); font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+    tr:hover td { background: var(--bg-alt); }
+    ul, ol { padding-left: var(--space-6); margin-bottom: var(--space-4); }
+    li { margin-bottom: var(--space-2); }
+    blockquote { border-left: 3px solid var(--accent); padding: var(--space-3) var(--space-4); margin: var(--space-4) 0; background: var(--bg-alt); border-radius: 0 var(--radius) var(--radius) 0; color: var(--text-secondary); }
+    hr { border: none; border-top: 1px solid var(--border); margin: var(--space-8) 0; }
+
+    /* ── Technical Proposal specific ── */
+    .proposal { max-width: var(--content-width); margin: 0 auto; padding: var(--space-8) var(--space-6); }
+
+    .proposal-header {
+      text-align: center;
+      padding-bottom: var(--space-8);
+      margin-bottom: var(--space-8);
+      border-bottom: 1px solid var(--border);
+    }
+    .proposal-header h1 { font-size: var(--font-size-3xl); margin-bottom: var(--space-4); }
+    .proposal-header .subtitle { font-size: var(--font-size-lg); color: var(--text-secondary); margin-bottom: var(--space-4); }
+    .proposal-meta {
+      display: flex; justify-content: center; gap: var(--space-6); flex-wrap: wrap;
+      font-size: var(--font-size-sm); color: var(--text-muted);
+    }
+
+    .status-bar {
+      display: flex; align-items: center; gap: var(--space-3);
+      background: var(--bg-alt); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-3) var(--space-4);
+      margin-bottom: var(--space-8); font-size: var(--font-size-sm);
+    }
+    .status-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .status-draft { background: var(--warning); }
+    .status-review { background: var(--accent); }
+    .status-approved { background: var(--success); }
+
+    section { margin-bottom: var(--space-10); }
+    section > h2 { font-size: var(--font-size-2xl); padding-bottom: var(--space-2); border-bottom: 1px solid var(--border); margin-top: var(--space-10); margin-bottom: var(--space-4); }
+    section > h3 { font-size: var(--font-size-xl); margin-top: var(--space-6); margin-bottom: var(--space-3); }
+    p { margin-bottom: var(--space-4); }
+
+    .diagram-placeholder {
+      background: var(--bg-alt); border: 2px dashed var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-8);
+      text-align: center; color: var(--text-muted); margin: var(--space-6) 0;
+    }
+
+    .decision-table { margin: var(--space-6) 0; }
+    .decision-table th:first-child { width: 30%; }
+
+    .pros-cons { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); margin: var(--space-6) 0; }
+    .pros, .cons {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-4);
+    }
+    .pros { border-top: 3px solid var(--success); }
+    .cons { border-top: 3px solid var(--error); }
+    .pros h4, .cons h4 { margin-top: 0; margin-bottom: var(--space-3); font-size: var(--font-size-base); }
+    .pros h4 { color: var(--success); }
+    .cons h4 { color: var(--error); }
+
+    .callout { padding: var(--space-4); border-radius: var(--radius); margin: var(--space-4) 0; border-left: 4px solid; }
+    .callout-info { background: var(--bg-alt); border-color: var(--accent); }
+    .callout-warning { background: var(--warning-light); border-color: var(--warning); }
+
+    .proposal-footer {
+      margin-top: var(--space-12); padding-top: var(--space-6);
+      border-top: 1px solid var(--border);
+      font-size: var(--font-size-sm); color: var(--text-muted); text-align: center;
+    }
+
+    @media print {
+      body { background: white; color: black; }
+      .proposal { max-width: none; padding: 0; }
+      .pros-cons { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 640px) {
+      .proposal { padding: var(--space-4); }
+      .proposal-meta { flex-direction: column; gap: var(--space-2); align-items: center; }
+      .pros-cons { grid-template-columns: 1fr; }
+      h1 { font-size: var(--font-size-2xl); }
+    }
+  </style>
+</head>
+<body>
+  <div class="proposal">
+
+    <header class="proposal-header">
+      <h1>{{TITLE}}</h1>
+      <p class="subtitle">{{SUBTITLE}}</p>
+      <div class="proposal-meta">
+        <span>Author: {{AUTHOR}}</span>
+        <span>Date: {{DATE}}</span>
+        <span>Version: {{VERSION}}</span>
+      </div>
+    </header>
+
+    <div class="status-bar">
+      <span class="status-dot status-draft"></span>
+      <strong>Status:</strong> {{STATUS}}
+      <span style="margin-left: auto; color: var(--text-muted);">Last updated: {{LAST_UPDATED}}</span>
+    </div>
+
+    <section>
+      <h2>1. Problem Statement</h2>
+      <p>{{PROBLEM_DESCRIPTION}}</p>
+    </section>
+
+    <section>
+      <h2>2. Proposed Solution</h2>
+      <p>{{SOLUTION_OVERVIEW}}</p>
+
+      <h3>2.1 Architecture</h3>
+      <div class="diagram-placeholder">
+        [Architecture diagram or Mermaid chart]
+      </div>
+      <p>{{ARCHITECTURE_DESCRIPTION}}</p>
+
+      <h3>2.2 Key Design Decisions</h3>
+      <table class="decision-table">
+        <thead>
+          <tr><th>Decision</th><th>Choice</th><th>Rationale</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>{{DECISION_1}}</td><td>{{CHOICE_1}}</td><td>{{RATIONALE_1}}</td></tr>
+          <tr><td>{{DECISION_2}}</td><td>{{CHOICE_2}}</td><td>{{RATIONALE_2}}</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>3. Alternatives Considered</h2>
+      <p>{{ALTERNATIVES_INTRO}}</p>
+
+      <div class="pros-cons">
+        <div class="pros">
+          <h4>Advantages</h4>
+          <ul>
+            <li>{{PRO_1}}</li>
+            <li>{{PRO_2}}</li>
+            <li>{{PRO_3}}</li>
+          </ul>
+        </div>
+        <div class="cons">
+          <h4>Trade-offs</h4>
+          <ul>
+            <li>{{CON_1}}</li>
+            <li>{{CON_2}}</li>
+            <li>{{CON_3}}</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>4. Implementation Plan</h2>
+
+      <div class="callout callout-info">
+        <strong>Estimated effort:</strong> {{EFFORT_ESTIMATE}}
+      </div>
+
+      <table>
+        <thead>
+          <tr><th>Phase</th><th>Scope</th><th>Timeline</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Phase 1</td><td>{{PHASE_1_SCOPE}}</td><td>{{PHASE_1_TIME}}</td></tr>
+          <tr><td>Phase 2</td><td>{{PHASE_2_SCOPE}}</td><td>{{PHASE_2_TIME}}</td></tr>
+          <tr><td>Phase 3</td><td>{{PHASE_3_SCOPE}}</td><td>{{PHASE_3_TIME}}</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>5. Risks & Mitigations</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Impact</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>{{RISK_1}}</td><td>{{IMPACT_1}}</td><td>{{MITIGATION_1}}</td></tr>
+          <tr><td>{{RISK_2}}</td><td>{{IMPACT_2}}</td><td>{{MITIGATION_2}}</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <footer class="proposal-footer">
+      Generated by Zylos &mdash; {{DATE}}
+    </footer>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes #55.

Adds the first reusable HTML report template library for Pages:

- `references/html-rendering.md` documents Markdown vs HTML rendering, file placement, artifact behavior, CSP constraints, and template usage
- `templates/html/base.css` defines shared design tokens and utility patterns
- `templates/html/README.md` explains available templates and usage guidance
- Adds 4 standalone HTML templates:
  - `research-report.html`
  - `technical-proposal.html`
  - `comparison.html`
  - `evaluation.html`

## Verification

- `npm test` - 103 passed, 0 failed
- Rendered all 4 templates through headless Chromium with realistic placeholder content
- Checked desktop `1280x1600` and mobile `390x1200` screenshots for layout overlap/clipping

## Notes

The templates are self-contained and dependency-free. They are adapted from common report layout patterns rather than copied third-party HTML/CSS.
