### PR TITLE
feat: upgrade HTML templates with SVG data visualization

### DIFF
--- a/references/html-rendering.md
+++ b/references/html-rendering.md
@@ -159,7 +159,7 @@ Examples of HTML artifacts already in use:
 
 ## Data Visualization
 
-Pages CSP blocks inline `<script>`, so JavaScript charting libraries (Chart.js, D3, etc.) cannot run. All charts must be **pure SVG + CSS** -- no JS required.
+Remote charting libraries (Chart.js, D3 via CDN, etc.) are blocked by the current CSP — only same-origin scripts are allowed. Inline scripts are permitted but not recommended for templates: pure SVG + CSS is easier to review, more portable, and has no JS dependency.
 
 The HTML templates in `templates/html/` include ready-to-use SVG chart placeholders. When generating reports, replace the `{{PLACEHOLDER}}` markers with computed values.
 

--- a/references/html-rendering.md
+++ b/references/html-rendering.md
@@ -156,3 +156,201 @@ Examples of HTML artifacts already in use:
 |------|------|-----------------|
 | `proposals/dgx-spark-backup-strategy.html` | Technical proposal | Two-column desktop layout, responsive, data classification table |
 | `renovation-checklist.html` | Interactive checklist | Collapsible phases, attachment blocks, editable via share links |
+
+## Data Visualization
+
+Pages CSP blocks inline `<script>`, so JavaScript charting libraries (Chart.js, D3, etc.) cannot run. All charts must be **pure SVG + CSS** -- no JS required.
+
+The HTML templates in `templates/html/` include ready-to-use SVG chart placeholders. When generating reports, replace the `{{PLACEHOLDER}}` markers with computed values.
+
+### Horizontal Bar Chart
+
+A horizontal bar chart uses SVG `<rect>` elements with variable widths. The bar width is calculated as a percentage of the chart area.
+
+```html
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 280" role="img" aria-label="Chart title">
+  <!-- Background grid lines -->
+  <line x1="160" y1="30" x2="160" y2="250" stroke="var(--border)" stroke-width="1"/>
+  <line x1="295" y1="30" x2="295" y2="250" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="4,4"/>
+  <line x1="430" y1="30" x2="430" y2="250" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="4,4"/>
+  <line x1="565" y1="30" x2="565" y2="250" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="4,4"/>
+  <line x1="700" y1="30" x2="700" y2="250" stroke="var(--border)" stroke-width="1"/>
+
+  <!-- Axis labels -->
+  <text x="160" y="268" fill="var(--text-muted)" font-size="11" text-anchor="middle">0</text>
+  <text x="430" y="268" fill="var(--text-muted)" font-size="11" text-anchor="middle">50</text>
+  <text x="700" y="268" fill="var(--text-muted)" font-size="11" text-anchor="middle">100</text>
+
+  <!-- Each row: label + background track + colored bar + value -->
+  <text x="150" y="56" fill="var(--text)" font-size="13" text-anchor="end" dominant-baseline="middle">Label</text>
+  <rect x="160" y="40" width="540" height="28" rx="4" fill="var(--chart-bar-bg)" opacity="0.4"/>
+  <rect x="160" y="40" width="459" height="28" rx="4" fill="var(--chart-bar-1)"/>
+  <!-- width = score/100 * 540 (chart area is 540px wide) -->
+  <text x="625" y="56" fill="var(--text)" font-size="12" font-weight="600" dominant-baseline="middle">85</text>
+</svg>
+```
+
+**Key formula:** bar width = `(score / 100) * 540` pixels. The chart area spans from x=160 to x=700 (540px). The value text x-position = 160 + bar_width + 6.
+
+### Pie Chart (SVG path arcs)
+
+Pie charts use SVG `<path>` elements with arc commands. Each segment is a "slice" drawn from the center.
+
+```html
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <!-- Each segment: path from center to arc -->
+  <!-- Segment formula: M cx,cy L startX,startY A r,r 0 large-arc-flag,1 endX,endY Z -->
+  <!-- Center: (200, 185), Radius: 140 -->
+
+  <!-- Segment 1: 45% = 162 degrees -->
+  <path d="M200,185 L340,185 A140,140 0 0,1 66.85,228.26 Z" fill="var(--chart-pie-blue)"/>
+
+  <!-- Segment 2: 35% = 126 degrees -->
+  <path d="M200,185 L66.85,228.26 A140,140 0 0,1 243.26,51.85 Z" fill="var(--chart-pie-purple)"/>
+
+  <!-- Segment 3: 20% = 72 degrees -->
+  <path d="M200,185 L243.26,51.85 A140,140 0 0,1 340,185 Z" fill="var(--chart-pie-teal)"/>
+
+  <!-- Percentage labels inside slices -->
+  <!-- Position at midpoint angle, ~60% of radius from center -->
+  <text x="214" y="274" fill="#ffffff" font-size="16" font-weight="700" text-anchor="middle">45%</text>
+</svg>
+```
+
+**Coordinate formulas:**
+- Degrees per segment = `(percentage / 100) * 360`
+- Arc endpoint: `x = cx + r * cos(angle_rad)`, `y = cy + r * sin(angle_rad)`
+- Large-arc-flag: `1` if segment > 180 degrees, else `0`
+- Label position: use ~60% of radius at the midpoint angle
+
+### Radar / Spider Chart (polygon coordinates)
+
+Radar charts use SVG `<polygon>` elements. Grid rings are concentric pentagons (or diamonds for 4 axes); data values are plotted as vertices of a filled polygon.
+
+```html
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" width="500" height="500">
+  <!-- Grid rings (concentric pentagons for 5 dimensions) -->
+  <!-- 100% ring (outer boundary) -->
+  <polygon points="250,60 421.2,184.4 355.8,385.6 144.2,385.6 78.8,184.4"
+    fill="none" stroke="var(--border-strong)" stroke-width="1" />
+  <!-- 80% ring -->
+  <polygon points="250,96 387,195.5 334.6,356.5 165.4,356.5 113,195.5"
+    fill="none" stroke="var(--border)" stroke-width="0.8" />
+  <!-- Additional rings at 60%, 40%, 20%... -->
+
+  <!-- Axis lines from center to each vertex -->
+  <line x1="250" y1="240" x2="250" y2="60" stroke="var(--border)" stroke-width="0.5" />
+  <!-- ... one line per dimension -->
+
+  <!-- Data polygon -->
+  <polygon points="250,78 395.5,192.7 343.1,368.1 175.9,341.9 92.5,188.8"
+    fill="var(--option-a)" fill-opacity="0.2"
+    stroke="var(--option-a)" stroke-width="2" />
+
+  <!-- Data points (dots) at each vertex -->
+  <circle cx="250" cy="78" r="4" fill="var(--option-a)" />
+
+  <!-- Dimension labels outside the chart -->
+  <text x="250" y="40" text-anchor="middle" fill="var(--text)" font-size="13">Dimension 1</text>
+  <text x="250" y="54" text-anchor="middle" fill="var(--text-muted)" font-size="10">90 / 75</text>
+</svg>
+```
+
+**Coordinate formulas (5-axis pentagon):**
+- Center: `(cx, cy)`, max radius: `R`
+- Axis angles: `angle_i = -90 + i * 72` degrees (i = 0..4), where -90 puts the first axis at top
+- Vertex at score `s` (0-100): `x = cx + (s/100)*R * cos(angle_rad)`, `y = cy + (s/100)*R * sin(angle_rad)`
+
+For a 4-axis diamond, use `angle_i = -90 + i * 90` degrees (i = 0..3).
+
+### Architecture Diagram (rect + line + marker arrows)
+
+Flow diagrams use SVG `<rect>` for boxes and `<line>`/`<path>` with arrowhead markers for connections.
+
+```html
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 300" width="700" height="300">
+  <!-- Define arrowhead marker -->
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="var(--svg-arrow)" />
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect x="0" y="0" width="700" height="300" rx="8" fill="var(--svg-bg)" />
+
+  <!-- Box -->
+  <rect x="255" y="20" width="190" height="52" rx="10"
+    fill="var(--svg-box-fill)" stroke="var(--svg-box-stroke)" stroke-width="2" />
+  <text x="350" y="42" text-anchor="middle" font-size="15" font-weight="600"
+    fill="var(--svg-box-text)">Component Name</text>
+  <text x="350" y="60" text-anchor="middle" font-size="11"
+    fill="var(--svg-arrow-label)">Subtitle</text>
+
+  <!-- Arrow between boxes -->
+  <line x1="350" y1="72" x2="350" y2="148"
+    stroke="var(--svg-arrow)" stroke-width="2" marker-end="url(#arrowhead)" />
+  <text x="370" y="115" text-anchor="start" font-size="11"
+    fill="var(--svg-arrow-label)">action label</text>
+
+  <!-- Feedback loop (dashed path) -->
+  <path d="M 255,264 L 30,264 L 30,46 L 253,46" fill="none"
+    stroke="var(--svg-arrow)" stroke-width="2" stroke-dasharray="6,3"
+    marker-end="url(#arrowhead)" />
+</svg>
+```
+
+**Tips:**
+- Use `rx="10"` on boxes for rounded corners
+- Use `stroke-dasharray="6,3"` for dashed feedback/return arrows
+- Use `orient="auto"` on markers so arrowheads rotate with line direction
+
+### Timeline / Gantt Chart
+
+Gantt charts use horizontal bars positioned on a time grid.
+
+```html
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 200" width="700" height="200">
+  <!-- Background -->
+  <rect x="0" y="0" width="700" height="200" rx="8" fill="var(--svg-bg)" />
+
+  <!-- Vertical grid lines (column separators) -->
+  <line x1="275" y1="40" x2="275" y2="170" stroke="var(--gantt-grid)" stroke-width="1" />
+  <line x1="410" y1="40" x2="410" y2="170" stroke="var(--gantt-grid)" stroke-width="1" />
+  <line x1="545" y1="40" x2="545" y2="170" stroke="var(--gantt-grid)" stroke-width="1" />
+
+  <!-- Column header labels -->
+  <text x="207" y="30" text-anchor="middle" font-size="12" font-weight="600"
+    fill="var(--gantt-text)">W1</text>
+
+  <!-- Phase label (left side) -->
+  <text x="130" y="73" text-anchor="end" font-size="13"
+    fill="var(--gantt-label)">Phase Name</text>
+
+  <!-- Track background -->
+  <rect x="140" y="55" width="540" height="30" rx="4" fill="var(--gantt-track)" />
+
+  <!-- Phase bar -->
+  <rect x="140" y="57" width="270" height="26" rx="6"
+    fill="var(--gantt-phase1)" opacity="0.9" />
+  <text x="275" y="75" text-anchor="middle" font-size="11" font-weight="600"
+    fill="#ffffff">Phase 1 (2 weeks)</text>
+</svg>
+```
+
+**Layout:** The chart area spans x=140 to x=680 (540px). Each column is `540 / num_columns` pixels wide. Bar x-position and width correspond to start/end columns.
+
+### Dark Mode Tips
+
+- **Use CSS custom properties** for all SVG colors: `fill="var(--text)"`, `stroke="var(--border)"`. Define light and dark values in `:root` and `@media (prefers-color-scheme: dark)`.
+- **Use `currentColor`** for simple cases where the SVG inherits the parent text color.
+- **Never hardcode colors** like `fill="#333"` in SVG elements -- they will be invisible in dark mode. The one exception is white text on colored backgrounds (pie chart labels, Gantt bar labels) which works in both modes.
+- **Define chart-specific CSS variables** (e.g. `--chart-bar-1`, `--svg-box-fill`, `--radar-accent`) with both light and dark variants to keep charts visually consistent.
+
+### Responsive Tips
+
+- **Always use `viewBox`** on SVG elements: `viewBox="0 0 700 280"`. This makes the SVG scale to its container without fixed pixel dimensions.
+- **Set percentage widths** on containers: wrap SVGs in a div with `width: 100%; overflow-x: auto;`.
+- **Use `max-width: 100%; height: auto;`** on the SVG element itself.
+- **For pie/radar charts**, set a max-width (e.g. `max-width: 400px; width: 100%;`) to prevent them from becoming too large on wide screens.
+- **Add `overflow-x: auto`** on the chart container div so horizontal charts can scroll on narrow screens rather than overflowing.

--- a/templates/html/comparison.html
+++ b/templates/html/comparison.html
@@ -124,6 +124,24 @@
     }
     .verdict h2 { color: var(--accent-text); margin-top: 0; margin-bottom: var(--space-3); }
 
+    /* -- Radar chart section -- */
+    .radar-section {
+      text-align: center;
+      margin-bottom: var(--space-8);
+    }
+    .radar-section h2 {
+      font-size: var(--font-size-xl); margin-bottom: var(--space-4);
+      padding-bottom: var(--space-2); border-bottom: 1px solid var(--border);
+    }
+    .radar-wrapper {
+      display: flex;
+      justify-content: center;
+    }
+    .radar-wrapper svg {
+      max-width: 100%;
+      height: auto;
+    }
+
     .comparison-footer {
       margin-top: var(--space-12); padding-top: var(--space-6);
       border-top: 1px solid var(--border);
@@ -159,6 +177,82 @@
       <div class="vs-option vs-option-b">{{OPTION_B}}</div>
     </div>
 
+    <!-- == Radar Chart == -->
+    <section class="radar-section">
+      <h2>{{RADAR_TITLE}}</h2>
+      <div class="radar-wrapper">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" width="500" height="500">
+          <!-- Background grid pentagons -->
+          <!-- 20% ring -->
+          <polygon points="250,204 284.2,228.9 271.2,269.1 228.8,269.1 215.8,228.9"
+            fill="none" stroke="var(--border)" stroke-width="0.5" />
+          <!-- 40% ring -->
+          <polygon points="250,168 318.5,217.8 292.3,298.2 207.7,298.2 181.5,217.8"
+            fill="none" stroke="var(--border)" stroke-width="0.5" />
+          <!-- 60% ring -->
+          <polygon points="250,132 352.7,206.6 313.5,327.4 186.5,327.4 147.3,206.6"
+            fill="none" stroke="var(--border)" stroke-width="0.5" />
+          <!-- 80% ring -->
+          <polygon points="250,96 387,195.5 334.6,356.5 165.4,356.5 113,195.5"
+            fill="none" stroke="var(--border)" stroke-width="0.8" />
+          <!-- 100% ring (outer boundary) -->
+          <polygon points="250,60 421.2,184.4 355.8,385.6 144.2,385.6 78.8,184.4"
+            fill="none" stroke="var(--border-strong)" stroke-width="1" />
+
+          <!-- Axis lines from center to each vertex -->
+          <line x1="250" y1="240" x2="250" y2="60" stroke="var(--border)" stroke-width="0.5" />
+          <line x1="250" y1="240" x2="421.2" y2="184.4" stroke="var(--border)" stroke-width="0.5" />
+          <line x1="250" y1="240" x2="355.8" y2="385.6" stroke="var(--border)" stroke-width="0.5" />
+          <line x1="250" y1="240" x2="144.2" y2="385.6" stroke="var(--border)" stroke-width="0.5" />
+          <line x1="250" y1="240" x2="78.8" y2="184.4" stroke="var(--border)" stroke-width="0.5" />
+
+          <!-- Option A polygon -->
+          <polygon points="{{RADAR_A_POINTS}}"
+            fill="var(--option-a)" fill-opacity="0.2"
+            stroke="var(--option-a)" stroke-width="2" />
+          <!-- Option A data points -->
+          <circle cx="{{RADAR_A_1_X}}" cy="{{RADAR_A_1_Y}}" r="4" fill="var(--option-a)" />
+          <circle cx="{{RADAR_A_2_X}}" cy="{{RADAR_A_2_Y}}" r="4" fill="var(--option-a)" />
+          <circle cx="{{RADAR_A_3_X}}" cy="{{RADAR_A_3_Y}}" r="4" fill="var(--option-a)" />
+          <circle cx="{{RADAR_A_4_X}}" cy="{{RADAR_A_4_Y}}" r="4" fill="var(--option-a)" />
+          <circle cx="{{RADAR_A_5_X}}" cy="{{RADAR_A_5_Y}}" r="4" fill="var(--option-a)" />
+
+          <!-- Option B polygon -->
+          <polygon points="{{RADAR_B_POINTS}}"
+            fill="var(--option-b)" fill-opacity="0.2"
+            stroke="var(--option-b)" stroke-width="2" />
+          <!-- Option B data points -->
+          <circle cx="{{RADAR_B_1_X}}" cy="{{RADAR_B_1_Y}}" r="4" fill="var(--option-b)" />
+          <circle cx="{{RADAR_B_2_X}}" cy="{{RADAR_B_2_Y}}" r="4" fill="var(--option-b)" />
+          <circle cx="{{RADAR_B_3_X}}" cy="{{RADAR_B_3_Y}}" r="4" fill="var(--option-b)" />
+          <circle cx="{{RADAR_B_4_X}}" cy="{{RADAR_B_4_Y}}" r="4" fill="var(--option-b)" />
+          <circle cx="{{RADAR_B_5_X}}" cy="{{RADAR_B_5_Y}}" r="4" fill="var(--option-b)" />
+
+          <!-- Dimension labels -->
+          <text x="250" y="40" text-anchor="middle" fill="var(--text)" font-size="13" font-family="var(--font-sans)">{{RADAR_DIM_1}}</text>
+          <text x="250" y="54" text-anchor="middle" fill="var(--text-muted)" font-size="10" font-family="var(--font-sans)">{{RADAR_A_1}} / {{RADAR_B_1}}</text>
+
+          <text x="438" y="180" text-anchor="start" fill="var(--text)" font-size="13" font-family="var(--font-sans)">{{RADAR_DIM_2}}</text>
+          <text x="438" y="194" text-anchor="start" fill="var(--text-muted)" font-size="10" font-family="var(--font-sans)">{{RADAR_A_2}} / {{RADAR_B_2}}</text>
+
+          <text x="373" y="404" text-anchor="start" fill="var(--text)" font-size="13" font-family="var(--font-sans)">{{RADAR_DIM_3}}</text>
+          <text x="373" y="418" text-anchor="start" fill="var(--text-muted)" font-size="10" font-family="var(--font-sans)">{{RADAR_A_3}} / {{RADAR_B_3}}</text>
+
+          <text x="127" y="404" text-anchor="end" fill="var(--text)" font-size="13" font-family="var(--font-sans)">{{RADAR_DIM_4}}</text>
+          <text x="127" y="418" text-anchor="end" fill="var(--text-muted)" font-size="10" font-family="var(--font-sans)">{{RADAR_A_4}} / {{RADAR_B_4}}</text>
+
+          <text x="62" y="180" text-anchor="end" fill="var(--text)" font-size="13" font-family="var(--font-sans)">{{RADAR_DIM_5}}</text>
+          <text x="62" y="194" text-anchor="end" fill="var(--text-muted)" font-size="10" font-family="var(--font-sans)">{{RADAR_A_5}} / {{RADAR_B_5}}</text>
+
+          <!-- Legend -->
+          <rect x="160" y="460" width="14" height="14" rx="2" fill="var(--option-a)" fill-opacity="0.7" />
+          <text x="180" y="472" fill="var(--text)" font-size="12" font-family="var(--font-sans)">{{OPTION_A}}</text>
+          <rect x="280" y="460" width="14" height="14" rx="2" fill="var(--option-b)" fill-opacity="0.7" />
+          <text x="300" y="472" fill="var(--text)" font-size="12" font-family="var(--font-sans)">{{OPTION_B}}</text>
+        </svg>
+      </div>
+    </section>
+
     <section class="dimension-section">
       <h2>Overall Scores</h2>
       <div class="score-row">
@@ -174,6 +268,27 @@
         <span class="score-value">{{SCORE_A2}}</span>
         <div class="score-bar-track"><div class="score-bar b" style="width: {{SCORE_B2}}%"></div></div>
         <span class="score-value">{{SCORE_B2}}</span>
+      </div>
+      <div class="score-row">
+        <span class="score-label">{{DIMENSION_3}}</span>
+        <div class="score-bar-track"><div class="score-bar a" style="width: {{SCORE_A3}}%"></div></div>
+        <span class="score-value">{{SCORE_A3}}</span>
+        <div class="score-bar-track"><div class="score-bar b" style="width: {{SCORE_B3}}%"></div></div>
+        <span class="score-value">{{SCORE_B3}}</span>
+      </div>
+      <div class="score-row">
+        <span class="score-label">{{DIMENSION_4}}</span>
+        <div class="score-bar-track"><div class="score-bar a" style="width: {{SCORE_A4}}%"></div></div>
+        <span class="score-value">{{SCORE_A4}}</span>
+        <div class="score-bar-track"><div class="score-bar b" style="width: {{SCORE_B4}}%"></div></div>
+        <span class="score-value">{{SCORE_B4}}</span>
+      </div>
+      <div class="score-row">
+        <span class="score-label">{{DIMENSION_5}}</span>
+        <div class="score-bar-track"><div class="score-bar a" style="width: {{SCORE_A5}}%"></div></div>
+        <span class="score-value">{{SCORE_A5}}</span>
+        <div class="score-bar-track"><div class="score-bar b" style="width: {{SCORE_B5}}%"></div></div>
+        <span class="score-value">{{SCORE_B5}}</span>
       </div>
     </section>
 

--- a/templates/html/evaluation.html
+++ b/templates/html/evaluation.html
@@ -25,6 +25,10 @@
       --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
       --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
       --content-width: 860px;
+      --radar-accent: #0d9488;
+      --radar-accent-fill: rgba(13, 148, 136, 0.25);
+      --radar-grid: #d1d5db;
+      --radar-axis: #9ca3af;
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -36,6 +40,10 @@
         --warning: #fbbf24; --warning-light: #451a03;
         --error: #f87171; --error-light: #450a0a;
         --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+        --radar-accent: #2dd4bf;
+        --radar-accent-fill: rgba(45, 212, 191, 0.25);
+        --radar-grid: #475569;
+        --radar-axis: #64748b;
       }
     }
     html { font-size: 16px; }
@@ -120,6 +128,58 @@
     }
     .next-steps h3 { margin-top: 0; margin-bottom: var(--space-4); }
 
+    /* -- Radar chart -- */
+    .radar-container {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-6); box-shadow: var(--shadow-sm);
+      text-align: center;
+    }
+    .radar-container h3 {
+      font-size: var(--font-size-lg); margin-bottom: var(--space-4); margin-top: 0;
+    }
+    .radar-container svg {
+      max-width: 400px; width: 100%; height: auto;
+    }
+
+    /* -- Progress bars -- */
+    .progress-container {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-8); box-shadow: var(--shadow-sm);
+    }
+    .progress-container h3 {
+      font-size: var(--font-size-lg); margin-bottom: var(--space-6); margin-top: 0;
+    }
+    .progress-item {
+      margin-bottom: var(--space-4);
+    }
+    .progress-item:last-child {
+      margin-bottom: 0;
+    }
+    .progress-header {
+      display: flex; justify-content: space-between; align-items: baseline;
+      margin-bottom: var(--space-2);
+      font-size: var(--font-size-sm); font-weight: 600;
+    }
+    .progress-label { color: var(--text); }
+    .progress-score { color: var(--text-secondary); font-family: var(--font-mono); }
+    .progress-track {
+      width: 100%; height: 12px;
+      background: var(--bg-alt); border-radius: 6px;
+      overflow: hidden; border: 1px solid var(--border);
+    }
+    .progress-fill {
+      height: 100%; border-radius: 6px;
+      animation: barGrow 1s ease-out forwards;
+    }
+    .progress-fill-high { background: var(--success); }
+    .progress-fill-mid { background: var(--warning); }
+
+    @keyframes barGrow {
+      from { width: 0; }
+    }
+
     .eval-footer {
       margin-top: var(--space-12); padding-top: var(--space-6);
       border-top: 1px solid var(--border);
@@ -130,6 +190,7 @@
       body { background: white; color: black; }
       .evaluation { max-width: none; padding: 0; }
       .verdict-banner { border: 2px solid; }
+      .progress-fill { animation: none; }
     }
     @media (max-width: 640px) {
       .evaluation { padding: var(--space-4); }
@@ -183,6 +244,95 @@
       <div class="score-item">
         <div class="score-number score-low">{{SCORE_4}}</div>
         <div class="score-dim">{{DIM_4}}</div>
+      </div>
+    </div>
+
+    <!-- Radar Chart -->
+    <div class="radar-container">
+      <h3>{{RADAR_CHART_TITLE}}</h3>
+      <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{{RADAR_CHART_TITLE}}">
+        <!-- Grid: 3 concentric diamond levels -->
+        <polygon points="200,50 350,200 200,350 50,200"
+          fill="none" stroke="var(--radar-grid)" stroke-width="1" />
+        <polygon points="200,100 300,200 200,300 100,200"
+          fill="none" stroke="var(--radar-grid)" stroke-width="1" stroke-dasharray="4,4" />
+        <polygon points="200,150 250,200 200,250 150,200"
+          fill="none" stroke="var(--radar-grid)" stroke-width="1" stroke-dasharray="4,4" />
+
+        <!-- Axis lines -->
+        <line x1="200" y1="50" x2="200" y2="350" stroke="var(--radar-axis)" stroke-width="1" stroke-dasharray="2,3" />
+        <line x1="50" y1="200" x2="350" y2="200" stroke="var(--radar-axis)" stroke-width="1" stroke-dasharray="2,3" />
+
+        <!-- Data polygon -->
+        <polygon points="{{RADAR_1_X}},{{RADAR_1_Y}} {{RADAR_2_X}},{{RADAR_2_Y}} {{RADAR_3_X}},{{RADAR_3_Y}} {{RADAR_4_X}},{{RADAR_4_Y}}"
+          fill="var(--radar-accent-fill)" stroke="var(--radar-accent)" stroke-width="2.5" />
+
+        <!-- Data points -->
+        <circle cx="{{RADAR_1_X}}" cy="{{RADAR_1_Y}}" r="5" fill="var(--radar-accent)" />
+        <circle cx="{{RADAR_2_X}}" cy="{{RADAR_2_Y}}" r="5" fill="var(--radar-accent)" />
+        <circle cx="{{RADAR_3_X}}" cy="{{RADAR_3_Y}}" r="5" fill="var(--radar-accent)" />
+        <circle cx="{{RADAR_4_X}}" cy="{{RADAR_4_Y}}" r="5" fill="var(--radar-accent)" />
+
+        <!-- Center dot -->
+        <circle cx="200" cy="200" r="2.5" fill="var(--radar-axis)" />
+
+        <!-- Dimension labels -->
+        <text x="200" y="32" text-anchor="middle" fill="var(--text)" font-size="14" font-weight="600" font-family="var(--font-sans)">{{RADAR_1_LABEL}}</text>
+        <text x="200" y="48" text-anchor="middle" fill="var(--text-muted)" font-size="12" font-family="var(--font-mono)">{{RADAR_1_VALUE}}</text>
+
+        <text x="365" y="200" text-anchor="start" dominant-baseline="middle" fill="var(--text)" font-size="14" font-weight="600" font-family="var(--font-sans)">{{RADAR_2_LABEL}}</text>
+        <text x="365" y="216" text-anchor="start" fill="var(--text-muted)" font-size="12" font-family="var(--font-mono)">{{RADAR_2_VALUE}}</text>
+
+        <text x="200" y="380" text-anchor="middle" fill="var(--text)" font-size="14" font-weight="600" font-family="var(--font-sans)">{{RADAR_3_LABEL}}</text>
+        <text x="200" y="396" text-anchor="middle" fill="var(--text-muted)" font-size="12" font-family="var(--font-mono)">{{RADAR_3_VALUE}}</text>
+
+        <text x="35" y="200" text-anchor="end" dominant-baseline="middle" fill="var(--text)" font-size="14" font-weight="600" font-family="var(--font-sans)">{{RADAR_4_LABEL}}</text>
+        <text x="35" y="216" text-anchor="end" fill="var(--text-muted)" font-size="12" font-family="var(--font-mono)">{{RADAR_4_VALUE}}</text>
+      </svg>
+    </div>
+
+    <!-- Progress Bars -->
+    <div class="progress-container">
+      <h3>{{PROGRESS_TITLE}}</h3>
+
+      <div class="progress-item">
+        <div class="progress-header">
+          <span class="progress-label">{{PROGRESS_1_LABEL}}</span>
+          <span class="progress-score">{{PROGRESS_1_SCORE}}</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill {{PROGRESS_1_CLASS}}" style="width: {{PROGRESS_1_PCT}}%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-item">
+        <div class="progress-header">
+          <span class="progress-label">{{PROGRESS_2_LABEL}}</span>
+          <span class="progress-score">{{PROGRESS_2_SCORE}}</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill {{PROGRESS_2_CLASS}}" style="width: {{PROGRESS_2_PCT}}%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-item">
+        <div class="progress-header">
+          <span class="progress-label">{{PROGRESS_3_LABEL}}</span>
+          <span class="progress-score">{{PROGRESS_3_SCORE}}</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill {{PROGRESS_3_CLASS}}" style="width: {{PROGRESS_3_PCT}}%;"></div>
+        </div>
+      </div>
+
+      <div class="progress-item">
+        <div class="progress-header">
+          <span class="progress-label">{{PROGRESS_4_LABEL}}</span>
+          <span class="progress-score">{{PROGRESS_4_SCORE}}</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill {{PROGRESS_4_CLASS}}" style="width: {{PROGRESS_4_PCT}}%;"></div>
+        </div>
       </div>
     </div>
 

--- a/templates/html/research-report.html
+++ b/templates/html/research-report.html
@@ -27,6 +27,16 @@
       --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
       --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
       --content-width: 860px;
+      /* -- Chart colors -- */
+      --chart-bar-1: #2563eb;
+      --chart-bar-2: #7c3aed;
+      --chart-bar-3: #059669;
+      --chart-bar-4: #d97706;
+      --chart-bar-5: #dc2626;
+      --chart-bar-bg: #e5e7eb;
+      --chart-pie-blue: #3b82f6;
+      --chart-pie-purple: #8b5cf6;
+      --chart-pie-teal: #14b8a6;
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -39,6 +49,15 @@
         --error: #f87171; --error-light: #450a0a;
         --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
         --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4), 0 2px 4px -2px rgba(0,0,0,0.3);
+        --chart-bar-1: #60a5fa;
+        --chart-bar-2: #a78bfa;
+        --chart-bar-3: #34d399;
+        --chart-bar-4: #fbbf24;
+        --chart-bar-5: #f87171;
+        --chart-bar-bg: #334155;
+        --chart-pie-blue: #60a5fa;
+        --chart-pie-purple: #a78bfa;
+        --chart-pie-teal: #2dd4bf;
       }
     }
     html { font-size: 16px; }
@@ -132,6 +151,23 @@
       text-align: center;
     }
 
+    /* -- Chart styles -- */
+    .chart-title {
+      font-size: var(--font-size-lg);
+      font-weight: 600;
+      margin-bottom: var(--space-4);
+      color: var(--text);
+    }
+    .chart-container {
+      width: 100%;
+      overflow-x: auto;
+    }
+    .chart-container svg {
+      display: block;
+      max-width: 100%;
+      height: auto;
+    }
+
     @media print {
       body { background: white; color: black; }
       .report { max-width: none; padding: 0; }
@@ -160,6 +196,86 @@
     <div class="executive-summary">
       <h2>Executive Summary</h2>
       <p>{{SUMMARY}}</p>
+    </div>
+
+    <!-- == Chart: Horizontal Bar Chart == -->
+    <div class="finding-card">
+      <h4 class="chart-title">{{BAR_CHART_TITLE}}</h4>
+      <div class="chart-container">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 280" role="img" aria-label="{{BAR_CHART_TITLE}}">
+          <!-- Background grid lines -->
+          <line x1="160" y1="30" x2="160" y2="250" stroke="var(--border)" stroke-width="1"/>
+          <line x1="295" y1="30" x2="295" y2="250" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="4,4"/>
+          <line x1="430" y1="30" x2="430" y2="250" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="4,4"/>
+          <line x1="565" y1="30" x2="565" y2="250" stroke="var(--border)" stroke-width="0.5" stroke-dasharray="4,4"/>
+          <line x1="700" y1="30" x2="700" y2="250" stroke="var(--border)" stroke-width="1"/>
+
+          <!-- Axis labels -->
+          <text x="160" y="268" fill="var(--text-muted)" font-size="11" font-family="var(--font-sans)" text-anchor="middle">0</text>
+          <text x="295" y="268" fill="var(--text-muted)" font-size="11" font-family="var(--font-sans)" text-anchor="middle">25</text>
+          <text x="430" y="268" fill="var(--text-muted)" font-size="11" font-family="var(--font-sans)" text-anchor="middle">50</text>
+          <text x="565" y="268" fill="var(--text-muted)" font-size="11" font-family="var(--font-sans)" text-anchor="middle">75</text>
+          <text x="700" y="268" fill="var(--text-muted)" font-size="11" font-family="var(--font-sans)" text-anchor="middle">100</text>
+
+          <!-- Row 1 -->
+          <text x="150" y="56" fill="var(--text)" font-size="13" font-family="var(--font-sans)" text-anchor="end" dominant-baseline="middle">{{BAR_1_LABEL}}</text>
+          <rect x="160" y="40" width="540" height="28" rx="4" fill="var(--chart-bar-bg)" opacity="0.4"/>
+          <rect x="160" y="40" width="{{BAR_1_WIDTH}}" height="28" rx="4" fill="var(--chart-bar-1)"/>
+          <text x="{{BAR_1_TEXT_X}}" y="56" fill="var(--text)" font-size="12" font-family="var(--font-sans)" font-weight="600" dominant-baseline="middle">{{BAR_1_VALUE}}</text>
+
+          <!-- Row 2 -->
+          <text x="150" y="100" fill="var(--text)" font-size="13" font-family="var(--font-sans)" text-anchor="end" dominant-baseline="middle">{{BAR_2_LABEL}}</text>
+          <rect x="160" y="84" width="540" height="28" rx="4" fill="var(--chart-bar-bg)" opacity="0.4"/>
+          <rect x="160" y="84" width="{{BAR_2_WIDTH}}" height="28" rx="4" fill="var(--chart-bar-2)"/>
+          <text x="{{BAR_2_TEXT_X}}" y="100" fill="var(--text)" font-size="12" font-family="var(--font-sans)" font-weight="600" dominant-baseline="middle">{{BAR_2_VALUE}}</text>
+
+          <!-- Row 3 -->
+          <text x="150" y="144" fill="var(--text)" font-size="13" font-family="var(--font-sans)" text-anchor="end" dominant-baseline="middle">{{BAR_3_LABEL}}</text>
+          <rect x="160" y="128" width="540" height="28" rx="4" fill="var(--chart-bar-bg)" opacity="0.4"/>
+          <rect x="160" y="128" width="{{BAR_3_WIDTH}}" height="28" rx="4" fill="var(--chart-bar-3)"/>
+          <text x="{{BAR_3_TEXT_X}}" y="144" fill="var(--text)" font-size="12" font-family="var(--font-sans)" font-weight="600" dominant-baseline="middle">{{BAR_3_VALUE}}</text>
+
+          <!-- Row 4 -->
+          <text x="150" y="188" fill="var(--text)" font-size="13" font-family="var(--font-sans)" text-anchor="end" dominant-baseline="middle">{{BAR_4_LABEL}}</text>
+          <rect x="160" y="172" width="540" height="28" rx="4" fill="var(--chart-bar-bg)" opacity="0.4"/>
+          <rect x="160" y="172" width="{{BAR_4_WIDTH}}" height="28" rx="4" fill="var(--chart-bar-4)"/>
+          <text x="{{BAR_4_TEXT_X}}" y="188" fill="var(--text)" font-size="12" font-family="var(--font-sans)" font-weight="600" dominant-baseline="middle">{{BAR_4_VALUE}}</text>
+
+          <!-- Row 5 -->
+          <text x="150" y="232" fill="var(--text)" font-size="13" font-family="var(--font-sans)" text-anchor="end" dominant-baseline="middle">{{BAR_5_LABEL}}</text>
+          <rect x="160" y="216" width="540" height="28" rx="4" fill="var(--chart-bar-bg)" opacity="0.4"/>
+          <rect x="160" y="216" width="{{BAR_5_WIDTH}}" height="28" rx="4" fill="var(--chart-bar-5)"/>
+          <text x="{{BAR_5_TEXT_X}}" y="232" fill="var(--text)" font-size="12" font-family="var(--font-sans)" font-weight="600" dominant-baseline="middle">{{BAR_5_VALUE}}</text>
+        </svg>
+      </div>
+    </div>
+
+    <!-- == Chart: Pie Chart == -->
+    <div class="finding-card">
+      <h4 class="chart-title">{{PIE_CHART_TITLE}}</h4>
+      <div class="chart-container" style="display: flex; flex-direction: column; align-items: center;">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400" role="img" aria-label="{{PIE_CHART_TITLE}}">
+          <!-- Segment 1 -->
+          <path d="{{PIE_1_PATH}}" fill="var(--chart-pie-blue)"/>
+          <!-- Segment 2 -->
+          <path d="{{PIE_2_PATH}}" fill="var(--chart-pie-purple)"/>
+          <!-- Segment 3 -->
+          <path d="{{PIE_3_PATH}}" fill="var(--chart-pie-teal)"/>
+
+          <!-- Percentage labels -->
+          <text x="{{PIE_1_LABEL_X}}" y="{{PIE_1_LABEL_Y}}" fill="#ffffff" font-size="16" font-weight="700" font-family="var(--font-sans)" text-anchor="middle" dominant-baseline="middle">{{PIE_1_PCT}}</text>
+          <text x="{{PIE_2_LABEL_X}}" y="{{PIE_2_LABEL_Y}}" fill="#ffffff" font-size="16" font-weight="700" font-family="var(--font-sans)" text-anchor="middle" dominant-baseline="middle">{{PIE_2_PCT}}</text>
+          <text x="{{PIE_3_LABEL_X}}" y="{{PIE_3_LABEL_Y}}" fill="#ffffff" font-size="16" font-weight="700" font-family="var(--font-sans)" text-anchor="middle" dominant-baseline="middle">{{PIE_3_PCT}}</text>
+
+          <!-- Legend -->
+          <rect x="60" y="355" width="14" height="14" rx="3" fill="var(--chart-pie-blue)"/>
+          <text x="80" y="366" fill="var(--text-secondary)" font-size="13" font-family="var(--font-sans)" dominant-baseline="middle">{{PIE_1_LABEL}}</text>
+          <rect x="195" y="355" width="14" height="14" rx="3" fill="var(--chart-pie-purple)"/>
+          <text x="215" y="366" fill="var(--text-secondary)" font-size="13" font-family="var(--font-sans)" dominant-baseline="middle">{{PIE_2_LABEL}}</text>
+          <rect x="310" y="355" width="14" height="14" rx="3" fill="var(--chart-pie-teal)"/>
+          <text x="330" y="366" fill="var(--text-secondary)" font-size="13" font-family="var(--font-sans)" dominant-baseline="middle">{{PIE_3_LABEL}}</text>
+        </svg>
+      </div>
     </div>
 
     <nav class="toc">

--- a/templates/html/technical-proposal.html
+++ b/templates/html/technical-proposal.html
@@ -25,6 +25,20 @@
       --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
       --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
       --content-width: 900px;
+      /* -- SVG diagram tokens -- */
+      --svg-box-fill: #ede9fe;
+      --svg-box-stroke: #7c3aed;
+      --svg-box-text: #4c1d95;
+      --svg-arrow: #7c3aed;
+      --svg-arrow-label: #4b5563;
+      --svg-bg: #faf5ff;
+      --gantt-phase1: #7c3aed;
+      --gantt-phase2: #a78bfa;
+      --gantt-phase3: #c4b5fd;
+      --gantt-track: #f3f0ff;
+      --gantt-grid: #e5e7eb;
+      --gantt-text: #1f2937;
+      --gantt-label: #4b5563;
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -37,6 +51,20 @@
         --error: #f87171; --error-light: #450a0a;
         --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
         --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4), 0 2px 4px -2px rgba(0,0,0,0.3);
+        /* -- SVG diagram tokens (dark) -- */
+        --svg-box-fill: #2e1065;
+        --svg-box-stroke: #a78bfa;
+        --svg-box-text: #e9d5ff;
+        --svg-arrow: #a78bfa;
+        --svg-arrow-label: #94a3b8;
+        --svg-bg: #1a1033;
+        --gantt-phase1: #a78bfa;
+        --gantt-phase2: #7c3aed;
+        --gantt-phase3: #6d28d9;
+        --gantt-track: #1e1040;
+        --gantt-grid: #334155;
+        --gantt-text: #e2e8f0;
+        --gantt-label: #94a3b8;
       }
     }
     html { font-size: 16px; }
@@ -112,6 +140,28 @@
     .callout-info { background: var(--bg-alt); border-color: var(--accent); }
     .callout-warning { background: var(--warning-light); border-color: var(--warning); }
 
+    /* -- SVG diagram containers -- */
+    .svg-diagram {
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: var(--space-4);
+      margin: var(--space-6) 0;
+      text-align: center;
+      overflow-x: auto;
+    }
+    .svg-diagram svg {
+      max-width: 100%;
+      height: auto;
+    }
+    .svg-diagram-title {
+      font-size: var(--font-size-sm);
+      color: var(--text-muted);
+      margin-bottom: var(--space-3);
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+
     .proposal-footer {
       margin-top: var(--space-12); padding-top: var(--space-6);
       border-top: 1px solid var(--border);
@@ -160,8 +210,66 @@
       <p>{{SOLUTION_OVERVIEW}}</p>
 
       <h3>2.1 Architecture</h3>
-      <div class="diagram-placeholder">
-        [Architecture diagram or Mermaid chart]
+      <!-- == Architecture Flow Diagram (inline SVG) == -->
+      <div class="svg-diagram">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 300" width="700" height="300" role="img" aria-label="{{ARCH_DIAGRAM_TITLE}}">
+          <title>{{ARCH_DIAGRAM_TITLE}}</title>
+
+          <defs>
+            <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+              <polygon points="0 0, 10 3.5, 0 7" fill="var(--svg-arrow)" />
+            </marker>
+            <marker id="arrowhead-up" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+              <polygon points="0 0, 10 3.5, 0 7" fill="var(--svg-arrow)" />
+            </marker>
+          </defs>
+
+          <rect x="0" y="0" width="700" height="300" rx="8" fill="var(--svg-bg)" />
+
+          <!-- Box 1: top center -->
+          <rect x="255" y="20" width="190" height="52" rx="10" fill="var(--svg-box-fill)" stroke="var(--svg-box-stroke)" stroke-width="2" />
+          <text x="350" y="42" text-anchor="middle" font-family="var(--font-sans)" font-size="15" font-weight="600" fill="var(--svg-box-text)">{{ARCH_BOX_1}}</text>
+          <text x="350" y="60" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_BOX_1_SUB}}</text>
+
+          <!-- Box 2: left -->
+          <rect x="40" y="150" width="170" height="52" rx="10" fill="var(--svg-box-fill)" stroke="var(--svg-box-stroke)" stroke-width="2" />
+          <text x="125" y="172" text-anchor="middle" font-family="var(--font-sans)" font-size="15" font-weight="600" fill="var(--svg-box-text)">{{ARCH_BOX_2}}</text>
+          <text x="125" y="190" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_BOX_2_SUB}}</text>
+
+          <!-- Box 3: center -->
+          <rect x="265" y="150" width="170" height="52" rx="10" fill="var(--svg-box-fill)" stroke="var(--svg-box-stroke)" stroke-width="2" />
+          <text x="350" y="172" text-anchor="middle" font-family="var(--font-sans)" font-size="15" font-weight="600" fill="var(--svg-box-text)">{{ARCH_BOX_3}}</text>
+          <text x="350" y="190" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_BOX_3_SUB}}</text>
+
+          <!-- Box 4: right -->
+          <rect x="490" y="150" width="170" height="52" rx="10" fill="var(--svg-box-fill)" stroke="var(--svg-box-stroke)" stroke-width="2" />
+          <text x="575" y="172" text-anchor="middle" font-family="var(--font-sans)" font-size="15" font-weight="600" fill="var(--svg-box-text)">{{ARCH_BOX_4}}</text>
+          <text x="575" y="190" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_BOX_4_SUB}}</text>
+
+          <!-- Box 5: bottom center -->
+          <rect x="255" y="248" width="190" height="42" rx="10" fill="var(--svg-box-fill)" stroke="var(--svg-box-stroke)" stroke-width="2" />
+          <text x="350" y="274" text-anchor="middle" font-family="var(--font-sans)" font-size="15" font-weight="600" fill="var(--svg-box-text)">{{ARCH_BOX_5}}</text>
+
+          <!-- Arrow: Box 1 to Box 2 -->
+          <line x1="280" y1="72" x2="170" y2="148" stroke="var(--svg-arrow)" stroke-width="2" marker-end="url(#arrowhead)" />
+          <text x="205" y="105" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_ARROW_1}}</text>
+
+          <!-- Arrow: Box 1 to Box 3 -->
+          <line x1="350" y1="72" x2="350" y2="148" stroke="var(--svg-arrow)" stroke-width="2" marker-end="url(#arrowhead)" />
+          <text x="370" y="115" text-anchor="start" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_ARROW_2}}</text>
+
+          <!-- Arrow: Box 3 to Box 4 -->
+          <line x1="435" y1="176" x2="488" y2="176" stroke="var(--svg-arrow)" stroke-width="2" marker-end="url(#arrowhead)" />
+          <text x="462" y="168" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_ARROW_3}}</text>
+
+          <!-- Arrow: Box 4 to Box 5 -->
+          <line x1="530" y1="202" x2="445" y2="248" stroke="var(--svg-arrow)" stroke-width="2" marker-end="url(#arrowhead)" />
+          <text x="505" y="230" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)">{{ARCH_ARROW_4}}</text>
+
+          <!-- Arrow: Box 5 back to Box 1 (feedback loop) -->
+          <path d="M 255,264 L 30,264 L 30,46 L 253,46" fill="none" stroke="var(--svg-arrow)" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrowhead-up)" />
+          <text x="30" y="160" text-anchor="middle" font-family="var(--font-sans)" font-size="11" fill="var(--svg-arrow-label)" transform="rotate(-90, 30, 160)">{{ARCH_ARROW_5}}</text>
+        </svg>
       </div>
       <p>{{ARCHITECTURE_DESCRIPTION}}</p>
 
@@ -218,6 +326,58 @@
           <tr><td>Phase 3</td><td>{{PHASE_3_SCOPE}}</td><td>{{PHASE_3_TIME}}</td></tr>
         </tbody>
       </table>
+
+      <!-- == Implementation Timeline / Gantt Chart == -->
+      <div class="svg-diagram">
+        <div class="svg-diagram-title">{{GANTT_TITLE}}</div>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 200" width="700" height="200" role="img" aria-label="{{GANTT_TITLE}}">
+          <title>{{GANTT_TITLE}}</title>
+
+          <rect x="0" y="0" width="700" height="200" rx="8" fill="var(--svg-bg)" />
+
+          <!-- Vertical grid lines -->
+          <line x1="275" y1="40" x2="275" y2="170" stroke="var(--gantt-grid)" stroke-width="1" />
+          <line x1="410" y1="40" x2="410" y2="170" stroke="var(--gantt-grid)" stroke-width="1" />
+          <line x1="545" y1="40" x2="545" y2="170" stroke="var(--gantt-grid)" stroke-width="1" />
+
+          <!-- Chart area border -->
+          <line x1="140" y1="40" x2="680" y2="40" stroke="var(--gantt-grid)" stroke-width="1" />
+          <line x1="140" y1="170" x2="680" y2="170" stroke="var(--gantt-grid)" stroke-width="1" />
+
+          <!-- Column labels -->
+          <text x="207" y="30" text-anchor="middle" font-family="var(--font-sans)" font-size="12" font-weight="600" fill="var(--gantt-text)">{{GANTT_COL_1}}</text>
+          <text x="342" y="30" text-anchor="middle" font-family="var(--font-sans)" font-size="12" font-weight="600" fill="var(--gantt-text)">{{GANTT_COL_2}}</text>
+          <text x="477" y="30" text-anchor="middle" font-family="var(--font-sans)" font-size="12" font-weight="600" fill="var(--gantt-text)">{{GANTT_COL_3}}</text>
+          <text x="612" y="30" text-anchor="middle" font-family="var(--font-sans)" font-size="12" font-weight="600" fill="var(--gantt-text)">{{GANTT_COL_4}}</text>
+
+          <!-- Phase labels -->
+          <text x="130" y="73" text-anchor="end" font-family="var(--font-sans)" font-size="13" fill="var(--gantt-label)">{{PHASE_1_TITLE}}</text>
+          <text x="130" y="113" text-anchor="end" font-family="var(--font-sans)" font-size="13" fill="var(--gantt-label)">{{PHASE_2_TITLE}}</text>
+          <text x="130" y="153" text-anchor="end" font-family="var(--font-sans)" font-size="13" fill="var(--gantt-label)">{{PHASE_3_TITLE}}</text>
+
+          <!-- Track backgrounds -->
+          <rect x="140" y="55" width="540" height="30" rx="4" fill="var(--gantt-track)" />
+          <rect x="140" y="95" width="540" height="30" rx="4" fill="var(--gantt-track)" />
+          <rect x="140" y="135" width="540" height="30" rx="4" fill="var(--gantt-track)" />
+
+          <!-- Phase 1 bar -->
+          <rect x="{{PHASE_1_X}}" y="57" width="{{PHASE_1_WIDTH}}" height="26" rx="6" fill="var(--gantt-phase1)" opacity="0.9" />
+          <text x="{{PHASE_1_TEXT_X}}" y="75" text-anchor="middle" font-family="var(--font-sans)" font-size="11" font-weight="600" fill="#ffffff">{{PHASE_1_BAR_LABEL}}</text>
+
+          <!-- Phase 2 bar -->
+          <rect x="{{PHASE_2_X}}" y="97" width="{{PHASE_2_WIDTH}}" height="26" rx="6" fill="var(--gantt-phase2)" opacity="0.9" />
+          <text x="{{PHASE_2_TEXT_X}}" y="115" text-anchor="middle" font-family="var(--font-sans)" font-size="11" font-weight="600" fill="#ffffff">{{PHASE_2_BAR_LABEL}}</text>
+
+          <!-- Phase 3 bar -->
+          <rect x="{{PHASE_3_X}}" y="137" width="{{PHASE_3_WIDTH}}" height="26" rx="6" fill="var(--gantt-phase3)" opacity="0.9" />
+          <text x="{{PHASE_3_TEXT_X}}" y="155" text-anchor="middle" font-family="var(--font-sans)" font-size="11" font-weight="600" fill="#ffffff">{{PHASE_3_BAR_LABEL}}</text>
+
+          <!-- Duration annotations -->
+          <text x="{{PHASE_1_TEXT_X}}" y="190" text-anchor="middle" font-family="var(--font-sans)" font-size="10" fill="var(--gantt-label)">{{PHASE_1_DURATION}}</text>
+          <text x="{{PHASE_2_TEXT_X}}" y="190" text-anchor="middle" font-family="var(--font-sans)" font-size="10" fill="var(--gantt-label)">{{PHASE_2_DURATION}}</text>
+          <text x="{{PHASE_3_TEXT_X}}" y="190" text-anchor="middle" font-family="var(--font-sans)" font-size="10" fill="var(--gantt-label)">{{PHASE_3_DURATION}}</text>
+        </svg>
+      </div>
     </section>
 
     <section>


### PR DESCRIPTION
## Summary

- Upgrade all 4 HTML templates (`research-report`, `technical-proposal`, `comparison`, `evaluation`) with inline SVG chart placeholders for data visualization
- Add CSS custom properties for chart colors with full dark mode support
- Add `Data Visualization` section to `references/html-rendering.md` with SVG snippet cookbook covering bar, pie, radar, architecture, and Gantt chart types

### Template changes

| Template | Charts added |
|----------|-------------|
| `research-report.html` | Horizontal bar chart (5 rows) + Pie chart (3 segments) |
| `technical-proposal.html` | Architecture flow diagram (5 boxes + arrows) + Gantt timeline (3 phases) |
| `comparison.html` | Radar/spider chart (5-dim, 2 options) + 3 additional score bar rows |
| `evaluation.html` | Radar chart (4-dim) + CSS progress bars (4 items) |

### Key constraints followed
- No inline `<script>` (CSP compatible)
- All SVG colors use CSS custom properties (`var(--text)`, `var(--border)`, etc.)
- Full dark mode support via `prefers-color-scheme` media query overrides
- Responsive via `viewBox` and percentage-width containers
- All existing template content and placeholders preserved

Closes #58

## Test plan

- [x] `npm test` passes (103/103)
- [ ] Visually verify each template sample renders correctly in browser
- [ ] Verify dark mode appearance for all chart types
- [ ] Check responsive behavior on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)