### PR TITLE
feat: add pages CLI for template creation and sharing (#61)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -43,7 +43,28 @@ dependencies: []
 
 # Zylos Pages
 
-Render Markdown files as styled web pages.
+Render Markdown and HTML files as styled web pages.
+
+## Creating HTML Pages (CLI)
+
+```bash
+PAGES_DIR="~/.claude/skills/pages"
+
+# List available templates
+node $PAGES_DIR/src/cli/pages.js templates
+
+# Create a page from template (writes to the correct content directory)
+node $PAGES_DIR/src/cli/pages.js create --template technical-proposal --slug docs/my-report
+
+# Edit the file — replace {{PLACEHOLDER}} values with content
+
+# Create a public share link (no login required)
+node $PAGES_DIR/src/cli/pages.js share docs/my-report --duration 30d
+```
+
+Templates: `technical-proposal`, `research-report`, `comparison`, `evaluation`.
+
+## Quick Start (Markdown)
 
 ```bash
 # Write a page

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "external-files": "node src/cli/external-files.js",
+    "pages": "node src/cli/pages.js",
     "test": "node --test"
   },
   "homepage": "https://github.com/zylos-ai/zylos-pages#readme",

--- a/src/cli/pages.js
+++ b/src/cli/pages.js
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { getConfig } from '../lib/config.js';
 import { createShare } from '../sharing/share-manager.js';
 import { normalizeSlug } from '../utils/slug.js';
+import { resolveSafePath } from '../security/pathGuard.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.resolve(__dirname, '../../templates/html');
@@ -83,6 +84,15 @@ function createPage(args) {
 
   const config = getConfig();
   const slug = normalizeSlug(args.slug);
+
+  // Validate slug stays within content root (rejects .. traversal)
+  try {
+    resolveSafePath(slug, config.contentDir);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+
   const outPath = path.join(config.contentDir, `${slug}.html`);
 
   const outDir = path.dirname(outPath);
@@ -115,6 +125,11 @@ function sharePage(args) {
   const duration = args.duration || '30d';
   const config = getConfig();
   const normalized = normalizeSlug(slug);
+
+  if (config.sharing?.enabled === false) {
+    console.error('Error: sharing is disabled in config (sharing.enabled=false)');
+    process.exit(1);
+  }
 
   const htmlPath = path.join(config.contentDir, `${normalized}.html`);
   const mdPath = path.join(config.contentDir, `${normalized}.md`);

--- a/src/cli/pages.js
+++ b/src/cli/pages.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+/**
+ * pages CLI — create pages from templates, manage share links.
+ *
+ * Usage:
+ *   node pages.js templates                          List available HTML templates
+ *   node pages.js create --template <name> --slug <path>   Copy template to content dir
+ *   node pages.js share <slug> [--duration 24h|7d|30d]     Create a share link
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getConfig } from '../lib/config.js';
+import { createShare } from '../sharing/share-manager.js';
+import { normalizeSlug } from '../utils/slug.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = path.resolve(__dirname, '../../templates/html');
+
+function printUsage() {
+  console.log(`pages CLI — create pages from templates, manage share links.
+
+Usage:
+  node pages.js templates                                   List available templates
+  node pages.js create --template <name> --slug <path>      Create page from template
+  node pages.js share <slug> [--duration 24h|7d|30d]        Create a share link
+
+Examples:
+  node pages.js templates
+  node pages.js create --template technical-proposal --slug docs/my-report
+  node pages.js share docs/my-report --duration 30d`);
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = { command };
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i];
+    if (token === '--template' && rest[i + 1]) { args.template = rest[++i]; continue; }
+    if (token === '--slug' && rest[i + 1]) { args.slug = rest[++i]; continue; }
+    if (token === '--duration' && rest[i + 1]) { args.duration = rest[++i]; continue; }
+    if (!token.startsWith('--') && !args.positional) { args.positional = token; }
+  }
+  return args;
+}
+
+function listTemplates() {
+  if (!fs.existsSync(TEMPLATES_DIR)) {
+    console.error(`Templates directory not found: ${TEMPLATES_DIR}`);
+    process.exit(1);
+  }
+  const files = fs.readdirSync(TEMPLATES_DIR).filter(f => f.endsWith('.html'));
+  if (files.length === 0) {
+    console.log('No templates found.');
+    return;
+  }
+  console.log('Available HTML templates:\n');
+  for (const f of files) {
+    const name = f.replace('.html', '');
+    console.log(`  ${name}`);
+  }
+  console.log(`\nUsage: node pages.js create --template <name> --slug <path>`);
+}
+
+function createPage(args) {
+  if (!args.template) {
+    console.error('Error: --template is required');
+    process.exit(1);
+  }
+  if (!args.slug) {
+    console.error('Error: --slug is required');
+    process.exit(1);
+  }
+
+  const templateFile = path.join(TEMPLATES_DIR, `${args.template}.html`);
+  if (!fs.existsSync(templateFile)) {
+    console.error(`Template not found: ${args.template}`);
+    console.error(`Run "node pages.js templates" to see available templates.`);
+    process.exit(1);
+  }
+
+  const config = getConfig();
+  const slug = normalizeSlug(args.slug);
+  const outPath = path.join(config.contentDir, `${slug}.html`);
+
+  const outDir = path.dirname(outPath);
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+
+  if (fs.existsSync(outPath)) {
+    console.error(`File already exists: ${outPath}`);
+    console.error('Delete it first or use a different slug.');
+    process.exit(1);
+  }
+
+  const template = fs.readFileSync(templateFile, 'utf8');
+  fs.writeFileSync(outPath, template);
+
+  console.log(`Created: ${outPath}`);
+  console.log(`Template: ${args.template}`);
+  console.log(`Slug: ${slug}`);
+  console.log(`\nEdit the file and replace {{PLACEHOLDER}} values with your content.`);
+}
+
+function sharePage(args) {
+  const slug = args.positional || args.slug;
+  if (!slug) {
+    console.error('Error: slug is required. Usage: node pages.js share <slug> [--duration 30d]');
+    process.exit(1);
+  }
+
+  const duration = args.duration || '30d';
+  const config = getConfig();
+  const normalized = normalizeSlug(slug);
+
+  const htmlPath = path.join(config.contentDir, `${normalized}.html`);
+  const mdPath = path.join(config.contentDir, `${normalized}.md`);
+  if (!fs.existsSync(htmlPath) && !fs.existsSync(mdPath)) {
+    console.error(`Page not found: ${normalized}`);
+    console.error(`Looked in: ${config.contentDir}`);
+    process.exit(1);
+  }
+
+  const result = createShare(normalized, duration, config.sharing || {});
+
+  const baseUrl = process.env.PAGES_BASE_URL || 'https://zylos01.jinglever.com/pages';
+  const shareUrl = `${baseUrl}/s/${result.tokenId}`;
+
+  console.log(`Share link created for: ${normalized}`);
+  console.log(`URL: ${shareUrl}`);
+  console.log(`Duration: ${duration}`);
+  console.log(`Expires: ${result.expiresAt ? new Date(result.expiresAt).toISOString() : 'never'}`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+switch (args.command) {
+  case 'templates':
+    listTemplates();
+    break;
+  case 'create':
+    createPage(args);
+    break;
+  case 'share':
+    sharePage(args);
+    break;
+  case undefined:
+  case '--help':
+  case 'help':
+    printUsage();
+    break;
+  default:
+    console.error(`Unknown command: ${args.command}`);
+    printUsage();
+    process.exit(1);
+}

--- a/src/cli/pages.js
+++ b/src/cli/pages.js
@@ -126,6 +126,13 @@ function sharePage(args) {
   const config = getConfig();
   const normalized = normalizeSlug(slug);
 
+  try {
+    resolveSafePath(normalized, config.contentDir);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+
   if (config.sharing?.enabled === false) {
     console.error('Error: sharing is disabled in config (sharing.enabled=false)');
     process.exit(1);


### PR DESCRIPTION
## Summary

- Adds `src/cli/pages.js` — CLI helper for creating pages from templates and managing share links
- Three commands: `templates`, `create --template <name> --slug <path>`, `share <slug> --duration <dur>`
- Eliminates wrong-directory and manual-template-copy failure modes
- Updates SKILL.md with CLI quick-start section at the top

Closes #61

## Test plan

- [x] `templates` — lists 4 templates correctly
- [x] `create` — copies template to content dir, creates subdirectories
- [x] `share` — creates share link via share-manager, outputs URL
- [x] Error cases: missing template, missing slug, nonexistent template, duplicate file, unknown command
- [x] Existing syntax check passes
- [ ] Code review by zylos0t

🤖 Generated with [Claude Code](https://claude.com/claude-code)