### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.0] - 2026-06-25
+
+### Added
+- **Pages CLI** (#61): `src/cli/pages.js` with three commands — `templates` (list available HTML templates), `create --template <name> --slug <path>` (create page from template in correct content directory), `share <slug> --duration <dur>` (create public share link). Eliminates wrong-directory and manual-template-copy failure modes for agents.
+- **SKILL.md CLI quick-start**: Added "Creating HTML Pages (CLI)" section at the top of SKILL.md for discoverability.
+
+### Security
+- Path traversal guard (`resolveSafePath()`) on both `create` and `share` commands — rejects slugs containing `..` segments.
+- `share` command respects `sharing.enabled=false` configuration.
+
 ## [0.3.1] - 2026-06-24
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.3.1
+version: 0.4.0
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.4.0 (package.json, package-lock.json, SKILL.md)
- Add changelog entry for Pages CLI feature (#61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)