### PR TITLE
feat: add interview-questions HTML template

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -82,7 +82,7 @@ echo "# Hello World" > ~/zylos/http/public/pages/hello.md
 
 ## HTML Report Templates
 
-Four standalone HTML templates are available in `templates/html/`:
+Five standalone HTML templates are available in `templates/html/`:
 
 | Template | Use case |
 |----------|----------|
@@ -90,5 +90,6 @@ Four standalone HTML templates are available in `templates/html/`:
 | `technical-proposal.html` | Technical proposals with architecture sections, pros/cons comparison |
 | `comparison.html` | A-vs-B product or technology comparisons with scoring |
 | `evaluation.html` | Candidate or vendor evaluations with rating breakdowns |
+| `interview-questions.html` | Interview question guides with hypotheses, pacing notes, and judgment framework |
 
 All templates share `templates/html/base.css` (design tokens, dark mode, CJK fonts, responsive layout). Copy a template, fill in content, and save as `.html` in the pages directory.

--- a/templates/html/README.md
+++ b/templates/html/README.md
@@ -12,6 +12,7 @@ The layouts are adapted from common open-source report patterns: executive summa
 | `technical-proposal.html` | Technical proposals, architecture documents, design specs | Purple |
 | `comparison.html` | A vs B comparisons, competitive analysis, feature matrices | Teal |
 | `evaluation.html` | Interview evaluations, candidate assessments, review reports | Teal-green |
+| `interview-questions.html` | Interview question guides with hypotheses, pacing, and judgment framework | Blue |
 
 ## Shared Design System
 

--- a/templates/html/interview-questions.html
+++ b/templates/html/interview-questions.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{TITLE}}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --font-size-base: 1rem; --font-size-sm: 0.875rem; --font-size-xs: 0.75rem;
+      --font-size-lg: 1.125rem; --font-size-xl: 1.25rem; --font-size-2xl: 1.5rem; --font-size-3xl: 1.875rem;
+      --line-height: 1.75; --line-height-tight: 1.3;
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+      --space-6: 1.5rem; --space-8: 2rem; --space-10: 2.5rem; --space-12: 3rem;
+      --radius: 0.375rem; --radius-lg: 0.5rem;
+      --bg: #ffffff; --bg-alt: #f8f9fb; --bg-card: #ffffff;
+      --text: #1f2937; --text-secondary: #4b5563; --text-muted: #9ca3af;
+      --border: #e5e7eb; --border-strong: #d1d5db;
+      --accent: #2563eb; --accent-light: #dbeafe; --accent-text: #1d4ed8;
+      --success: #059669; --success-light: #d1fae5;
+      --warning: #d97706; --warning-light: #fef3c7;
+      --error: #dc2626; --error-light: #fee2e2;
+      --info: #0891b2; --info-light: #cffafe;
+      --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+      --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05);
+      --content-width: 860px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a; --bg-alt: #1e293b; --bg-card: #1e293b;
+        --text: #e2e8f0; --text-secondary: #94a3b8; --text-muted: #64748b;
+        --border: #334155; --border-strong: #475569;
+        --accent: #60a5fa; --accent-light: #1e3a5f; --accent-text: #93bbfc;
+        --success: #34d399; --success-light: #064e3b;
+        --warning: #fbbf24; --warning-light: #451a03;
+        --error: #f87171; --error-light: #450a0a;
+        --info: #22d3ee; --info-light: #083344;
+        --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+      }
+    }
+    html { font-size: 16px; }
+    body { font-family: var(--font-sans); font-size: var(--font-size-base); line-height: var(--line-height); color: var(--text); background: var(--bg); -webkit-font-smoothing: antialiased; }
+    h1, h2, h3, h4 { line-height: var(--line-height-tight); font-weight: 600; }
+    a { color: var(--accent); text-decoration: none; }
+    code { font-family: var(--font-mono); font-size: 0.9em; background: var(--bg-alt); padding: 0.15em 0.35em; border-radius: 3px; border: 1px solid var(--border); }
+    table { width: 100%; border-collapse: collapse; margin-bottom: var(--space-6); font-size: var(--font-size-sm); }
+    th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border); }
+    th { font-weight: 600; color: var(--text-secondary); font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+    ul, ol { padding-left: var(--space-6); margin-bottom: var(--space-4); }
+    li { margin-bottom: var(--space-2); }
+    p { margin-bottom: var(--space-4); }
+    hr { border: none; border-top: 1px solid var(--border); margin: var(--space-8) 0; }
+
+    /* ── Interview Questions specific ── */
+    .page { max-width: var(--content-width); margin: 0 auto; padding: var(--space-8) var(--space-6); }
+
+    .page-header { margin-bottom: var(--space-8); }
+    .page-header h1 { font-size: var(--font-size-3xl); margin-bottom: var(--space-3); }
+    .page-header .subtitle { font-size: var(--font-size-lg); color: var(--text-secondary); margin-bottom: var(--space-4); }
+
+    .meta-card {
+      display: grid; grid-template-columns: 1fr 1fr;
+      gap: var(--space-3);
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-6); box-shadow: var(--shadow-sm);
+      font-size: var(--font-size-sm);
+    }
+    .meta-label { color: var(--text-muted); font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+    .meta-value { color: var(--text); font-weight: 500; margin-bottom: var(--space-3); }
+
+    .prior-round {
+      background: var(--info-light); border: 1px solid var(--info);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-6);
+    }
+    .prior-round h3 { color: var(--info); margin-top: 0; margin-bottom: var(--space-3); font-size: var(--font-size-lg); }
+    .prior-round ul { margin-bottom: 0; }
+    .tag-confirmed { color: var(--success); font-weight: 600; }
+    .tag-weakness { color: var(--error); font-weight: 600; }
+    .tag-pending { color: var(--warning); font-weight: 600; }
+
+    .hypothesis-box {
+      background: var(--warning-light); border: 1px solid var(--warning);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-8);
+    }
+    .hypothesis-box h3 { color: var(--warning); margin-top: 0; margin-bottom: var(--space-3); font-size: var(--font-size-lg); }
+    .hypothesis-box ol { margin-bottom: 0; }
+
+    .pacing-note {
+      background: var(--bg-alt); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-4) var(--space-6);
+      margin-bottom: var(--space-8); font-size: var(--font-size-sm); color: var(--text-secondary);
+    }
+    .pacing-note strong { color: var(--text); }
+
+    section { margin-bottom: var(--space-8); }
+    section > h2 {
+      font-size: var(--font-size-xl); margin-bottom: var(--space-6);
+      padding-bottom: var(--space-2); border-bottom: 2px solid var(--accent);
+      color: var(--accent-text);
+    }
+
+    .badge {
+      display: inline-block; font-size: var(--font-size-xs); font-weight: 600;
+      padding: 0.15em 0.6em; border-radius: 9999px;
+      background: var(--error-light); color: var(--error);
+      vertical-align: middle; margin-left: var(--space-2);
+    }
+    .badge-new { background: var(--accent-light); color: var(--accent-text); }
+    .badge-optional { background: var(--info-light); color: var(--info); }
+
+    .question-block {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-6); box-shadow: var(--shadow-sm);
+      border-left: 4px solid var(--accent);
+    }
+    .question-block h3 {
+      font-size: var(--font-size-lg); margin-top: 0; margin-bottom: var(--space-4);
+      display: flex; align-items: center; gap: var(--space-2);
+    }
+    .q-num {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 28px; height: 28px; border-radius: 50%;
+      background: var(--accent); color: white;
+      font-size: var(--font-size-sm); font-weight: 700; flex-shrink: 0;
+    }
+    .question-text {
+      font-size: var(--font-size-base); line-height: var(--line-height);
+      margin-bottom: var(--space-4);
+    }
+    .interviewer-note {
+      background: var(--bg-alt); border-left: 3px solid var(--accent);
+      padding: var(--space-3) var(--space-4);
+      border-radius: 0 var(--radius) var(--radius) 0;
+      font-size: var(--font-size-sm); color: var(--text-secondary);
+      margin-bottom: var(--space-3);
+    }
+    .interviewer-note strong { color: var(--accent-text); }
+    .followup {
+      font-size: var(--font-size-sm); color: var(--text-secondary);
+      padding-left: var(--space-4); border-left: 2px dashed var(--border);
+    }
+    .followup strong { color: var(--text); }
+
+    .supplementary {
+      background: var(--bg-alt); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      margin-bottom: var(--space-8);
+    }
+    .supplementary h3 { margin-top: 0; margin-bottom: var(--space-4); }
+
+    .judgment-table {
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: var(--space-6);
+      box-shadow: var(--shadow-sm); margin-bottom: var(--space-8);
+    }
+    .judgment-table h3 { margin-top: 0; margin-bottom: var(--space-4); }
+    .judgment-table table { margin-bottom: 0; }
+    .verdict-pass { color: var(--success); font-weight: 600; }
+    .verdict-lean { color: var(--accent-text); font-weight: 600; }
+    .verdict-hold { color: var(--warning); font-weight: 600; }
+    .verdict-fail { color: var(--error); font-weight: 600; }
+
+    .page-footer {
+      margin-top: var(--space-12); padding-top: var(--space-6);
+      border-top: 1px solid var(--border);
+      font-size: var(--font-size-sm); color: var(--text-muted); text-align: center;
+    }
+
+    @media print {
+      body { background: white; color: black; }
+      .page { max-width: none; padding: 0; }
+      .question-block { break-inside: avoid; }
+    }
+    @media (max-width: 640px) {
+      .page { padding: var(--space-4); }
+      .meta-card { grid-template-columns: 1fr; }
+      h1 { font-size: var(--font-size-2xl); }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+
+    <header class="page-header">
+      <h1>{{TITLE}}</h1>
+      <div class="subtitle">{{ROLE}} &mdash; {{DURATION}} min</div>
+    </header>
+
+    <!-- ── Candidate Info ── -->
+    <div class="meta-card">
+      <div>
+        <div class="meta-label">Candidate</div>
+        <div class="meta-value">{{CANDIDATE_NAME}}</div>
+      </div>
+      <div>
+        <div class="meta-label">Current Role</div>
+        <div class="meta-value">{{CURRENT_ROLE}}</div>
+      </div>
+      <div>
+        <div class="meta-label">AI Evaluation</div>
+        <div class="meta-value">{{AI_EVAL_SUMMARY}}</div>
+      </div>
+      <div>
+        <div class="meta-label">Interview Date</div>
+        <div class="meta-value">{{DATE}}</div>
+      </div>
+    </div>
+
+    <!-- ── Prior Round Summary (remove this block for first-round interviews) ── -->
+    <div class="prior-round">
+      <h3>{{PRIOR_ROUND_TITLE}}</h3>
+      <ul>
+        <li><span class="tag-confirmed">[Confirmed]</span> {{CONFIRMED_1}}</li>
+        <li><span class="tag-confirmed">[Confirmed]</span> {{CONFIRMED_2}}</li>
+        <li><span class="tag-weakness">[Weakness]</span> {{WEAKNESS_1}}</li>
+        <li><span class="tag-pending">[Pending]</span> {{PENDING_1}}</li>
+      </ul>
+    </div>
+
+    <!-- ── Core Hypotheses ── -->
+    <div class="hypothesis-box">
+      <h3>{{HYPOTHESES_TITLE}}</h3>
+      <ol>
+        <li><strong>{{HYPOTHESIS_1_LABEL}}:</strong> {{HYPOTHESIS_1_DETAIL}}</li>
+        <li><strong>{{HYPOTHESIS_2_LABEL}}:</strong> {{HYPOTHESIS_2_DETAIL}}</li>
+        <li><strong>{{HYPOTHESIS_3_LABEL}}:</strong> {{HYPOTHESIS_3_DETAIL}}</li>
+      </ol>
+    </div>
+
+    <!-- ── Pacing Note ── -->
+    <div class="pacing-note">
+      <strong>Pacing:</strong> {{PACING_NOTE}}
+    </div>
+
+    <!-- ═══ Question Section ═══ -->
+    <section>
+      <h2>{{SECTION_1_TITLE}} <span class="badge">{{SECTION_1_BADGE}}</span></h2>
+
+      <div class="question-block">
+        <h3><span class="q-num">1</span> {{Q1_TITLE}}</h3>
+        <div class="question-text">{{Q1_TEXT}}</div>
+        <div class="interviewer-note">
+          <strong>Note:</strong> {{Q1_NOTE}}
+        </div>
+        <div class="followup">
+          <strong>Follow-up:</strong> {{Q1_FOLLOWUP}}
+        </div>
+      </div>
+
+      <div class="question-block">
+        <h3><span class="q-num">2</span> {{Q2_TITLE}}</h3>
+        <div class="question-text">{{Q2_TEXT}}</div>
+        <div class="interviewer-note">
+          <strong>Note:</strong> {{Q2_NOTE}}
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>{{SECTION_2_TITLE}} <span class="badge">{{SECTION_2_BADGE}}</span></h2>
+
+      <div class="question-block">
+        <h3><span class="q-num">3</span> {{Q3_TITLE}}</h3>
+        <div class="question-text">{{Q3_TEXT}}</div>
+        <div class="interviewer-note">
+          <strong>Note:</strong> {{Q3_NOTE}}
+        </div>
+      </div>
+
+      <div class="question-block">
+        <h3><span class="q-num">4</span> {{Q4_TITLE}}</h3>
+        <div class="question-text">{{Q4_TEXT}}</div>
+        <div class="interviewer-note">
+          <strong>Note:</strong> {{Q4_NOTE}}
+        </div>
+      </div>
+    </section>
+
+    <!-- Add more sections as needed by copying the pattern above -->
+
+    <hr>
+
+    <!-- ── Supplementary Notes ── -->
+    <div class="supplementary">
+      <h3>{{SUPPLEMENTARY_TITLE}}</h3>
+      <ul>
+        <li><strong>{{SUPP_1_LABEL}}:</strong> {{SUPP_1_DETAIL}}</li>
+        <li><strong>{{SUPP_2_LABEL}}:</strong> {{SUPP_2_DETAIL}}</li>
+        <li><strong>{{SUPP_3_LABEL}}:</strong> {{SUPP_3_DETAIL}}</li>
+      </ul>
+    </div>
+
+    <!-- ── Judgment Framework ── -->
+    <div class="judgment-table">
+      <h3>{{JUDGMENT_TITLE}}</h3>
+      <table>
+        <thead>
+          <tr><th>Result</th><th>Criteria</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="verdict-pass">{{VERDICT_1_LABEL}}</td>
+            <td>{{VERDICT_1_CRITERIA}}</td>
+          </tr>
+          <tr>
+            <td class="verdict-lean">{{VERDICT_2_LABEL}}</td>
+            <td>{{VERDICT_2_CRITERIA}}</td>
+          </tr>
+          <tr>
+            <td class="verdict-hold">{{VERDICT_3_LABEL}}</td>
+            <td>{{VERDICT_3_CRITERIA}}</td>
+          </tr>
+          <tr>
+            <td class="verdict-fail">{{VERDICT_4_LABEL}}</td>
+            <td>{{VERDICT_4_CRITERIA}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <footer class="page-footer">
+      Generated by Zylos &mdash; {{DATE}}
+    </footer>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New `interview-questions.html` template in `templates/html/` for structured interview question guides
- Includes: candidate info card, prior round summary, core hypotheses, numbered question blocks with interviewer notes/follow-ups, pacing notes, supplementary checks, judgment framework table
- Badge variants: required (red), new (blue), optional (teal)
- Updated `README.md` and `SKILL.md` to list the new template

## Context
Born from a real use case — generating tailored interview questions for recruit candidates. The existing `evaluation.html` template is designed for post-interview assessments (scores, verdicts, strengths/concerns), not pre-interview question guides. This template fills that gap.

## Test plan
- [ ] `node pages.js templates` lists `interview-questions`
- [ ] `node pages.js create --template interview-questions --slug test/iq` copies template correctly
- [ ] Template renders correctly in light and dark mode
- [ ] Print layout doesn't break question blocks across pages
- [ ] Mobile responsive at 640px breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)