### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.2] - 2026-06-25
+
+### Changed
+- **Interview questions template side-by-side layout** (#66): Question blocks now use CSS Grid two-column layout — left column for question/notes/follow-ups, right column for reference answers (good/bad indicators + notes). Content width expanded to 1260px. Responsive fallback to single column below 900px.
+
 ## [0.4.1] - 2026-06-25
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.4.1
+version: 0.4.2
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.4.2 (package.json, package-lock.json, SKILL.md)
- Add changelog entry for #66 (interview-questions template side-by-side reference answer layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)