### PR TITLE
feat: allow HTML files in external-files registration

### DIFF
--- a/src/cli/external-files.js
+++ b/src/cli/external-files.js
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DATA_DIR, getConfig } from '../lib/config.js';
-import { resolveSafePath } from '../security/pathGuard.js';
+import { resolvePagePath } from '../security/pathGuard.js';
 import { normalizeSlug } from '../utils/slug.js';
 
 const REGISTRY_PATH = path.join(DATA_DIR, 'external-files.json');
@@ -394,7 +394,8 @@ function commandRegister(args) {
   const component = args.component;
   const allowedRoot = resolveAllowedRoot(externalConfig, component);
   const sourceRealPath = resolveSource(args.source, allowedRoot);
-  const linkPath = resolveSafePath(slug, externalConfig.contentDir);
+  const linkExtension = path.extname(sourceRealPath).toLowerCase();
+  const linkPath = resolvePagePath(slug, externalConfig.contentDir, linkExtension);
   const now = new Date().toISOString();
   let createdLink = false;
 

--- a/src/cli/external-files.js
+++ b/src/cli/external-files.js
@@ -121,9 +121,11 @@ function normalizeAndValidateSlug(rawSlug) {
   return slug;
 }
 
-function assertMarkdown(filePath) {
-  if (path.extname(filePath).toLowerCase() !== '.md') {
-    throw new CliError('source_not_markdown', 'source must be a Markdown .md file');
+const ALLOWED_EXTENSIONS = new Set(['.md', '.html']);
+
+function assertAllowedExtension(filePath) {
+  if (!ALLOWED_EXTENSIONS.has(path.extname(filePath).toLowerCase())) {
+    throw new CliError('source_not_allowed', 'source must be a .md or .html file');
   }
 }
 
@@ -148,7 +150,7 @@ function resolveSource(sourcePath, allowedRoot) {
   if (!sourcePath || !path.isAbsolute(sourcePath)) {
     throw new CliError('source_missing', 'source must be an absolute path');
   }
-  assertMarkdown(sourcePath);
+  assertAllowedExtension(sourcePath);
 
   let sourceRealPath;
   try {
@@ -156,7 +158,7 @@ function resolveSource(sourcePath, allowedRoot) {
   } catch {
     throw new CliError('source_missing', 'source file does not exist');
   }
-  assertMarkdown(sourceRealPath);
+  assertAllowedExtension(sourceRealPath);
 
   if (!isInsideRoot(sourceRealPath, allowedRoot)) {
     throw new CliError('source_outside_allowed_root', 'source is outside the configured allowed root');

--- a/src/security/pathGuard.js
+++ b/src/security/pathGuard.js
@@ -117,6 +117,23 @@ export function resolveSafePath(slug, contentRoot) {
   return resolveCandidate(slug, contentRoot, '.md');
 }
 
+const PAGE_EXTENSIONS = new Set(['.md', '.html']);
+
+/**
+ * Resolve a slug to a page link path within the content root using the given
+ * extension. Only the renderable page extensions (.md, .html) are permitted,
+ * so an external HTML source links to `<slug>.html` and is served as an HTML
+ * artifact rather than through the Markdown path.
+ */
+export function resolvePagePath(slug, contentRoot, extension) {
+  validateSlug(slug);
+  const ext = String(extension).toLowerCase();
+  if (!PAGE_EXTENSIONS.has(ext)) {
+    throw new PathViolationError('Invalid path: only .md or .html files allowed');
+  }
+  return resolveCandidate(slug, contentRoot, ext);
+}
+
 /**
  * Resolve an allowlisted static asset path within the content root.
  */

--- a/test/external-files.test.js
+++ b/test/external-files.test.js
@@ -213,16 +213,46 @@ test('source symlink escaping allowed root is rejected', () => {
   assert.equal(result.code, 'source_outside_allowed_root');
 });
 
-test('missing and non-markdown sources are rejected', () => {
+test('missing and disallowed-extension sources are rejected', () => {
   const fixture = makeFixture();
   const txt = path.join(fixture.sourceRoot, 'notes.txt');
-  fs.writeFileSync(txt, 'not markdown\n');
+  fs.writeFileSync(txt, 'not a page\n');
 
-  const nonMarkdown = runCli(fixture, registerArgs('notes', txt), { expectFailure: true });
-  assert.equal(nonMarkdown.code, 'source_not_markdown');
+  const disallowed = runCli(fixture, registerArgs('notes', txt), { expectFailure: true });
+  assert.equal(disallowed.code, 'source_not_allowed');
 
   const missing = runCli(fixture, registerArgs('missing', path.join(fixture.sourceRoot, 'missing.md')), { expectFailure: true });
   assert.equal(missing.code, 'source_missing');
+});
+
+test('html source registers as an .html link and resolves as an html page', async () => {
+  const fixture = makeFixture();
+  const source = path.join(fixture.sourceRoot, 'artifact.html');
+  fs.writeFileSync(source, '<!doctype html><title>Artifact</title><h1>Artifact</h1>\n');
+
+  const result = runCli(fixture, registerArgs('recruit/artifact', source));
+  assert.equal(result.ok, true);
+
+  const linkPath = path.join(fixture.contentDir, 'recruit/artifact.html');
+  assert.equal(result.linkPath, linkPath);
+  assert.equal(fs.existsSync(path.join(fixture.contentDir, 'recruit/artifact.md')), false);
+  assert.equal(fs.lstatSync(linkPath).isSymbolicLink(), true);
+  assert.equal(fs.realpathSync(linkPath), fs.realpathSync(source));
+
+  const { resolvePageDescriptor } = await import('../src/security/pathGuard.js');
+  const descriptor = await resolvePageDescriptor('recruit/artifact', fixture.contentDir);
+  assert.equal(descriptor.type, 'html');
+  assert.equal(descriptor.filePath, linkPath);
+});
+
+test('markdown source still registers as an .md link', () => {
+  const fixture = makeFixture();
+  const source = path.join(fixture.sourceRoot, 'notes.md');
+  fs.writeFileSync(source, '# Notes\n');
+
+  const result = runCli(fixture, registerArgs('recruit/notes', source));
+  assert.equal(result.ok, true);
+  assert.equal(result.linkPath, path.join(fixture.contentDir, 'recruit/notes.md'));
 });
 
 test('existing normal page is not overwritten', () => {


### PR DESCRIPTION
## Summary
- Updated `external-files.js` to accept `.html` files in addition to `.md`
- Renamed `assertMarkdown()` to `assertAllowedExtension()` with a set of allowed extensions
- Enables components like recruit to register HTML artifacts (e.g. interview question pages using the interview-questions template)

## Test plan
- [ ] Register a `.md` file — should still work
- [ ] Register a `.html` file — should now work
- [ ] Register a `.txt` file — should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)