### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0] - 2026-06-27
+
+### Added
+- **HTML files in external-files registration** (#69): External-files registration now accepts `.html` sources. An `.html` source is linked at a `<slug>.html` path and rendered as a full-page HTML artifact (type `html`), instead of being misrouted through the Markdown pipeline. The symlink extension is now derived from the source file rather than hardcoded to `.md`, so future non-markdown source types register correctly.
+
 ## [0.4.2] - 2026-06-25
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.4.2
+version: 0.5.0
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release v0.5.0 — ships the HTML external-files registration capability merged in #69.

## Changes
- Bump version to 0.5.0 across `package.json`, `package-lock.json`, and `SKILL.md` frontmatter
- CHANGELOG entry for #69 (HTML files in external-files registration)

## Included feature (already merged via #69)
- External-files registration now accepts `.html` sources, linked at `<slug>.html` and rendered as `type: html` artifacts (no longer misrouted through the Markdown pipeline). Symlink extension derived from source rather than hardcoded `.md`.

Tests: 105/105 passing.