### PR TITLE
feat: merge admin root and signed share assets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,6 @@ import { setupLogicalAssetRoute } from './routes/logical-assets.js';
 import { setupPageApi } from './routes/page-api.js';
 import { adminRoute } from './routes/admin.js';
 import { pageRoute } from './routes/pages.js';
-import { indexRoute } from './routes/index.js';
 import { logger } from './utils/logger.js';
 
 // Initialize
@@ -99,7 +98,7 @@ async function main() {
 
   // Share API routes (after auth — requires authenticated session)
   if (sharingConfig.enabled !== false) {
-    setupShareApi(app, sharingConfig);
+    setupShareApi(app, sharingConfig, config);
   }
   setupRawApi(app, config);
   setupStateApi(app);
@@ -107,8 +106,7 @@ async function main() {
   setupPageApi(app, config);
 
   // Routes
-  app.get('/', indexRoute(config));
-  app.get('/admin', adminRoute());
+  app.get('/', adminRoute());
   setupLogicalAssetRoute(app, config);
   setupAssetRoute(app, config);
   app.get('/:slug(*)', pageRoute(config));

--- a/src/pages/asset-resolver.js
+++ b/src/pages/asset-resolver.js
@@ -1,8 +1,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { getLogicalPage } from './page-store.js';
+import { resolvePageDescriptor } from '../security/pathGuard.js';
 import { getMimeType, isAssetExtension } from '../utils/mime.js';
 import { normalizeSlug } from '../utils/slug.js';
+import {
+  createShareAssetSignature,
+  shareAssetExpiresAt,
+} from '../sharing/share-manager.js';
 
 export class AssetResolutionError extends Error {
   constructor(statusCode, message) {
@@ -15,6 +20,34 @@ export class AssetResolutionError extends Error {
 function isInsideRoot(filePath, rootPath) {
   const rel = path.relative(rootPath, filePath);
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+function expandHome(value) {
+  if (typeof value !== 'string') return value;
+  if (value === '~') return process.env.HOME;
+  if (value.startsWith('~/')) return path.join(process.env.HOME, value.slice(2));
+  return value;
+}
+
+async function allowedSourceRootRealPaths(config = {}) {
+  const roots = new Set();
+  if (config.contentDir) roots.add(config.contentDir);
+  for (const root of Object.values(config.externalFiles?.allowedSources || {})) {
+    if (typeof root === 'string' && root) roots.add(expandHome(root));
+  }
+  for (const root of Object.values(config.sourceRegistry?.allowedSources || {})) {
+    if (typeof root === 'string' && root) roots.add(expandHome(root));
+  }
+
+  const realRoots = [];
+  for (const root of roots) {
+    try {
+      realRoots.push(await fs.realpath(root));
+    } catch {
+      // Ignore missing configured roots; page registration validates them.
+    }
+  }
+  return realRoots;
 }
 
 function decodeAssetPath(rawPath) {
@@ -41,6 +74,11 @@ export function logicalAssetPath(baseUrl, pageUri, relativePath) {
   return `${cleanBase}/assets/${encodeURI(normalizeSlug(pageUri))}?${new URLSearchParams({ path: relativePath }).toString()}`;
 }
 
+function signedLogicalAssetPath(baseUrl, pageUri, relativePath, { exp, sig }) {
+  const cleanBase = baseUrl || '';
+  return `${cleanBase}/assets/${encodeURI(normalizeSlug(pageUri))}?${new URLSearchParams({ path: relativePath, exp: String(exp), sig }).toString()}`;
+}
+
 export function rewriteRelativeAssetRefs(html, { baseUrl = '', pageUri }) {
   if (!html || !pageUri) return html;
   return html.replace(/\b(src|href)=("([^"]*)"|'([^']*)')/gi, (full, attr, quoted, doubleValue, singleValue) => {
@@ -54,12 +92,24 @@ export function rewriteRelativeAssetRefs(html, { baseUrl = '', pageUri }) {
   });
 }
 
-export async function resolveLogicalAsset(pageUri, rawRelativePath) {
+async function pageSourceForAsset(pageUri, config = {}) {
   const page = getLogicalPage(pageUri);
-  if (!page) {
+  if (page) return { sourcePath: page.sourcePath };
+  if (!config.contentDir) {
     throw new AssetResolutionError(404, 'Page not found');
   }
+  try {
+    const descriptor = await resolvePageDescriptor(pageUri, config.contentDir);
+    return { sourcePath: descriptor.filePath };
+  } catch (err) {
+    if (err.statusCode) throw new AssetResolutionError(err.statusCode, err.message);
+    throw new AssetResolutionError(404, 'Page not found');
+  }
+}
 
+export async function resolveLogicalAsset(pageUri, rawRelativePath, options = {}) {
+  const { config = {}, allowConfiguredRoots = false } = options;
+  const page = await pageSourceForAsset(pageUri, config);
   const decoded = decodeAssetPath(rawRelativePath);
   const [assetPathOnly] = decoded.split(/[?#]/, 1);
   const extension = path.extname(assetPathOnly).toLowerCase();
@@ -69,7 +119,7 @@ export async function resolveLogicalAsset(pageUri, rawRelativePath) {
 
   const sourceDir = path.dirname(page.sourcePath);
   const candidate = path.resolve(sourceDir, assetPathOnly);
-  if (!isInsideRoot(candidate, sourceDir)) {
+  if (!allowConfiguredRoots && !isInsideRoot(candidate, sourceDir)) {
     throw new AssetResolutionError(400, 'Invalid asset path: outside page source directory');
   }
 
@@ -80,7 +130,12 @@ export async function resolveLogicalAsset(pageUri, rawRelativePath) {
     throw new AssetResolutionError(404, 'Asset not found');
   }
 
-  if (!isInsideRoot(realPath, sourceDir)) {
+  if (allowConfiguredRoots) {
+    const roots = await allowedSourceRootRealPaths(config);
+    if (!roots.some(root => isInsideRoot(realPath, root))) {
+      throw new AssetResolutionError(400, 'Invalid asset path: outside allowed source roots');
+    }
+  } else if (!isInsideRoot(realPath, sourceDir)) {
     throw new AssetResolutionError(400, 'Invalid asset path: outside page source directory');
   }
   if (path.extname(realPath).toLowerCase() !== extension) {
@@ -93,3 +148,116 @@ export async function resolveLogicalAsset(pageUri, rawRelativePath) {
   };
 }
 
+function isSameOriginAssetUrl(value, baseUrl) {
+  const cleanBase = baseUrl || '';
+  return value.startsWith(`${cleanBase}/assets/`) || (!cleanBase && value.startsWith('/assets/'));
+}
+
+function parseLogicalAssetUrl(value, baseUrl) {
+  const cleanBase = baseUrl || '';
+  const prefix = `${cleanBase}/assets/`;
+  if (!value.startsWith(prefix)) return null;
+  const afterPrefix = value.slice(prefix.length);
+  const queryIndex = afterPrefix.indexOf('?');
+  if (queryIndex === -1) return null;
+  const uri = decodeURIComponent(afterPrefix.slice(0, queryIndex));
+  const params = new URLSearchParams(afterPrefix.slice(queryIndex + 1));
+  const assetPath = params.get('path');
+  if (!uri || !assetPath) return null;
+  return { uri, assetPath };
+}
+
+function splitUrlSuffix(value) {
+  const hashIndex = value.indexOf('#');
+  const queryIndex = value.indexOf('?');
+  const indexes = [hashIndex, queryIndex].filter(index => index >= 0);
+  const splitAt = indexes.length ? Math.min(...indexes) : -1;
+  if (splitAt === -1) return { pathPart: value, suffix: '' };
+  return { pathPart: value.slice(0, splitAt), suffix: value.slice(splitAt) };
+}
+
+async function signAssetReference(value, context) {
+  if (!value || value.startsWith('#') || value.startsWith('?')) return value;
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(value)) return value;
+  if (value.startsWith(`${context.baseUrl || ''}/_assets/`) || value.startsWith('/_assets/')) return value;
+
+  let uri = context.pageUri;
+  let assetPath = value;
+  const existing = isSameOriginAssetUrl(value, context.baseUrl) ? parseLogicalAssetUrl(value, context.baseUrl) : null;
+  if (existing) {
+    uri = existing.uri;
+    assetPath = existing.assetPath;
+  } else {
+    if (value.startsWith('/')) return value;
+    const { pathPart } = splitUrlSuffix(value);
+    if (!isAssetExtension(path.extname(pathPart).toLowerCase())) return value;
+  }
+
+  try {
+    const resolved = await resolveLogicalAsset(uri, assetPath, {
+      config: context.config,
+      allowConfiguredRoots: true,
+    });
+    const exp = shareAssetExpiresAt(context.share.expiresAt);
+    const sig = createShareAssetSignature({
+      uri: context.pageUri,
+      realPath: resolved.filePath,
+      expiresAt: exp,
+      tokenId: context.share.tokenId,
+    });
+    return signedLogicalAssetPath(context.baseUrl, context.pageUri, assetPath, { exp, sig });
+  } catch {
+    return value;
+  }
+}
+
+async function rewriteSrcset(value, context) {
+  const candidates = value.split(',').map(part => part.trim()).filter(Boolean);
+  const rewritten = [];
+  for (const candidate of candidates) {
+    const [url, ...descriptor] = candidate.split(/\s+/);
+    rewritten.push([await signAssetReference(url, context), ...descriptor].join(' '));
+  }
+  return rewritten.join(', ');
+}
+
+async function replaceAsync(input, regex, replacer) {
+  const pieces = [];
+  let lastIndex = 0;
+  for (const match of input.matchAll(regex)) {
+    pieces.push(input.slice(lastIndex, match.index));
+    pieces.push(await replacer(...match));
+    lastIndex = match.index + match[0].length;
+  }
+  pieces.push(input.slice(lastIndex));
+  return pieces.join('');
+}
+
+export async function rewriteSignedShareAssetRefs(html, { baseUrl = '', pageUri, config, share }) {
+  if (!html || !pageUri || !share?.tokenId) return html;
+  const context = { baseUrl, pageUri: normalizeSlug(pageUri), config, share };
+  let output = await replaceAsync(
+    html,
+    /\b(src|href)=("([^"]*)"|'([^']*)')/gi,
+    async (full, attr, quoted, doubleValue, singleValue) => {
+      const value = doubleValue ?? singleValue ?? '';
+      const rewritten = await signAssetReference(value, context);
+      return `${attr}=${quoted[0]}${rewritten}${quoted[0]}`;
+    }
+  );
+  output = await replaceAsync(
+    output,
+    /\bsrcset=("([^"]*)"|'([^']*)')/gi,
+    async (_full, quoted, doubleValue, singleValue) => {
+      const value = doubleValue ?? singleValue ?? '';
+      const rewritten = await rewriteSrcset(value, context);
+      return `srcset=${quoted[0]}${rewritten}${quoted[0]}`;
+    }
+  );
+  output = await replaceAsync(
+    output,
+    /url\((["']?)([^"')]+)\1\)/gi,
+    async (_full, quote, value) => `url(${quote}${await signAssetReference(value.trim(), context)}${quote})`
+  );
+  return output;
+}

--- a/src/routes/logical-assets.js
+++ b/src/routes/logical-assets.js
@@ -1,5 +1,6 @@
 import { readFile, stat } from 'node:fs/promises';
 import { resolveLogicalAsset } from '../pages/asset-resolver.js';
+import { verifyShareAssetSignature } from '../sharing/share-manager.js';
 import { generateEtag } from '../utils/etag.js';
 import { logger } from '../utils/logger.js';
 
@@ -10,7 +11,23 @@ export function setupLogicalAssetRoute(app, config) {
     if (!pageUri || typeof assetPath !== 'string') return next();
 
     try {
-      const { filePath, mimeType } = await resolveLogicalAsset(pageUri, assetPath);
+      const signedRequest = typeof req.query.exp === 'string' || typeof req.query.sig === 'string';
+      const { filePath, mimeType } = await resolveLogicalAsset(pageUri, assetPath, {
+        config,
+        allowConfiguredRoots: signedRequest,
+      });
+      if (signedRequest) {
+        const verification = verifyShareAssetSignature({
+          uri: pageUri,
+          realPath: filePath,
+          expiresAt: Number(req.query.exp),
+          sig: req.query.sig,
+        });
+        if (!verification.valid) {
+          return res.status(403).send('Invalid asset signature');
+        }
+        res.locals.viewerType = 'share';
+      }
       const info = await stat(filePath);
       const maxFileSizeBytes = config.security?.maxFileSizeBytes ?? 1048576;
       if (info.size > maxFileSizeBytes) {
@@ -36,4 +53,3 @@ export function setupLogicalAssetRoute(app, config) {
     }
   });
 }
-

--- a/src/routes/pages.js
+++ b/src/routes/pages.js
@@ -4,6 +4,7 @@ import { getPage } from '../services/pageService.js';
 import { normalizeSlug } from '../utils/slug.js';
 import { notFoundTemplate, errorTemplate } from '../templates/errorTemplate.js';
 import { injectShareViewer, injectNavSidebar, htmlArtifactTemplate } from '../templates/pageTemplate.js';
+import { rewriteSignedShareAssetRefs } from '../pages/asset-resolver.js';
 import { scanPages } from './index.js';
 import { logger } from '../utils/logger.js';
 import { browserBaseFromRequest, browserPath } from '../lib/browser-base.js';
@@ -18,129 +19,166 @@ function redirectCleanExtension(req, res, browserBase, rawSlug, extension) {
   return res.redirect(301, `${browserPath(browserBase, clean)}${query}`);
 }
 
-/**
- * Route handler for GET /:slug(*)
- */
-export function pageRoute(config) {
-  return async (req, res) => {
-    const start = performance.now();
-    const browserBase = browserBaseFromRequest(req);
-    const rawSlug = req.params.slug || req.params[0] || req.path.slice(1) || '';
-    const isLogicalRoute = rawSlug.startsWith('p/');
-    const routeSlug = isLogicalRoute ? rawSlug.slice(2) : rawSlug;
+function injectBaseHref(html, baseHref) {
+  const baseTag = `<base href="${baseHref}">`;
+  const injected = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
+  return injected === html ? `${baseTag}${html}` : injected;
+}
 
-    // Redirect explicit extension URLs to clean URLs.
-    if (/\.md$/i.test(rawSlug)) {
-      return redirectCleanExtension(req, res, browserBase, rawSlug, 'md');
-    }
-    if (/\.html$/i.test(rawSlug)) {
-      return redirectCleanExtension(req, res, browserBase, rawSlug, 'html');
-    }
+async function finalizeShareHtml(html, { config, browserBase, displaySlug, share }) {
+  let output = injectBaseHref(html, browserPath(browserBase, displaySlug));
+  output = await rewriteSignedShareAssetRefs(output, {
+    baseUrl: browserBase,
+    pageUri: displaySlug.startsWith('p/') ? displaySlug.slice(2) : displaySlug,
+    config,
+    share,
+  });
+  return output;
+}
 
-    const slug = normalizeSlug(routeSlug);
-    const displaySlug = isLogicalRoute ? `p/${slug}` : slug;
+async function renderPageSlug({ req, res, config, browserBase, rawSlug, shareContext = null }) {
+  const start = performance.now();
+  const isLogicalRoute = rawSlug.startsWith('p/');
+  const routeSlug = isLogicalRoute ? rawSlug.slice(2) : rawSlug;
 
-    // Redirect if slug was normalized differently
-    if (routeSlug && slug !== routeSlug && slug !== decodeURIComponent(routeSlug)) {
-      return res.redirect(301, browserPath(browserBase, displaySlug));
-    }
+  // Redirect explicit extension URLs to clean URLs.
+  if (/\.md$/i.test(rawSlug)) {
+    return redirectCleanExtension(req, res, browserBase, rawSlug, 'md');
+  }
+  if (/\.html$/i.test(rawSlug)) {
+    return redirectCleanExtension(req, res, browserBase, rawSlug, 'html');
+  }
 
-    const isShareViewer = res.locals.viewerType === 'share';
-    const shareCanWriteAttachments = res.locals.shareCanWriteAttachments === true;
+  const slug = normalizeSlug(routeSlug);
+  const displaySlug = isLogicalRoute ? `p/${slug}` : slug;
 
-    try {
-      const result = await getPage(displaySlug, config, browserBase);
-      const elapsed = Math.round(performance.now() - start);
-      const isHtmlArtifact = result.type === 'html';
+  // Redirect if slug was normalized differently
+  if (routeSlug && slug !== routeSlug && slug !== decodeURIComponent(routeSlug)) {
+    return res.redirect(301, browserPath(browserBase, displaySlug));
+  }
 
-      // Raw mode serves the HTML artifact directly. Share viewers also receive
-      // the artifact directly because shared HTML is a complete page design.
-      if (isHtmlArtifact && (req.query.raw === '1' || isShareViewer)) {
-        res.setHeader('Content-Security-Policy', HTML_ARTIFACT_CSP);
-        res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-        if (!isShareViewer) {
-          const clientEtag = req.headers['if-none-match'];
-          if (clientEtag && clientEtag === result.etag) {
-            logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: 'auth', type: 'html-raw' });
-            return res.status(304).end();
-          }
-          res.setHeader('ETag', result.etag);
-          res.setHeader('Cache-Control', 'public, max-age=60');
-        } else {
-          res.setHeader('Cache-Control', 'no-store');
-        }
-        res.setHeader('Content-Type', 'text/html; charset=utf-8');
-        logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: 'html-raw' });
-        const baseTag = `<script>window.__PAGES_BASE=${JSON.stringify(browserBase)};window.__PAGES_VIEWER=${JSON.stringify(isShareViewer ? 'share' : 'auth')};window.__PAGES_SHARE_EDITABLE=${shareCanWriteAttachments ? 'true' : 'false'};</script>`;
-        let injected = result.html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
-        if (injected === result.html) injected = baseTag + result.html;
-        const viewerAttr = isShareViewer ? ` data-viewer="share"` : '';
-        const editableAttr = shareCanWriteAttachments ? ` data-share-editable="true"` : '';
-        injected = injected.replace(/<html([^>]*)>/i, `<html$1${viewerAttr}${editableAttr}>`);
-        injected = injected.replace(/src="([^"?]*_assets\/[^"?]+)"/g, `src="$1?v=${ASSET_VERSION}"`);
-        return res.send(injected);
-      }
+  const isShareViewer = Boolean(shareContext) || res.locals.viewerType === 'share';
+  const shareCanWriteAttachments = shareContext
+    ? shareContext.canWriteAttachments === true
+    : res.locals.shareCanWriteAttachments === true;
 
-      // ETag / 304 handling — skip for share viewers because post-cache
-      // injections (editable flag, viewer attr) are not reflected in the ETag.
-      const wrapperEtag = isHtmlArtifact ? `"${result.etag.replace(/"/g, '')}-wrapped"` : result.etag;
+  try {
+    const result = await getPage(displaySlug, config, browserBase);
+    const elapsed = Math.round(performance.now() - start);
+    const isHtmlArtifact = result.type === 'html';
+
+    // Raw mode serves the HTML artifact directly. Share viewers also receive
+    // the artifact directly because shared HTML is a complete page design.
+    if (isHtmlArtifact && (req.query.raw === '1' || isShareViewer)) {
+      res.setHeader('Content-Security-Policy', HTML_ARTIFACT_CSP);
+      res.setHeader('X-Frame-Options', 'SAMEORIGIN');
       if (!isShareViewer) {
         const clientEtag = req.headers['if-none-match'];
-        if (clientEtag && clientEtag === wrapperEtag) {
-          logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: 'auth', type: result.type });
+        if (clientEtag && clientEtag === result.etag) {
+          logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: 'auth', type: 'html-raw' });
           return res.status(304).end();
         }
-        res.setHeader('ETag', wrapperEtag);
+        res.setHeader('ETag', result.etag);
         res.setHeader('Cache-Control', 'public, max-age=60');
       } else {
         res.setHeader('Cache-Control', 'no-store');
       }
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
-
-      if (isHtmlArtifact) {
-        const titleMatch = result.html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
-        const title = titleMatch ? titleMatch[1].replace(/\s+/g, ' ').trim() : slug;
-        const iframeSrc = browserPath(browserBase, `${displaySlug}?raw=1`);
-        let html = htmlArtifactTemplate({ title, baseUrl: browserBase, slug: displaySlug, iframeSrc });
-        if (isShareViewer) {
-          html = injectShareViewer(html, { canWriteAttachments: shareCanWriteAttachments });
-        } else {
-          const pages = await scanPages(config.contentDir);
-          html = injectNavSidebar(html, pages, displaySlug, browserBase);
-        }
-        logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: result.type });
-        return res.send(html);
+      logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: 'html-raw' });
+      const baseTag = `<script>window.__PAGES_BASE=${JSON.stringify(browserBase)};window.__PAGES_VIEWER=${JSON.stringify(isShareViewer ? 'share' : 'auth')};window.__PAGES_SHARE_EDITABLE=${shareCanWriteAttachments ? 'true' : 'false'};</script>`;
+      let injected = result.html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
+      if (injected === result.html) injected = baseTag + result.html;
+      const viewerAttr = isShareViewer ? ` data-viewer="share"` : '';
+      const editableAttr = shareCanWriteAttachments ? ` data-share-editable="true"` : '';
+      injected = injected.replace(/<html([^>]*)>/i, `<html$1${viewerAttr}${editableAttr}>`);
+      injected = injected.replace(/src="([^"?]*_assets\/[^"?]+)"/g, `src="$1?v=${ASSET_VERSION}"`);
+      if (isShareViewer) {
+        injected = await finalizeShareHtml(injected, { config, browserBase, displaySlug, share: shareContext || res.locals.shareContext });
       }
+      return res.send(injected);
+    }
 
-      // For share viewers: inject data-viewer attribute to hide auth-only elements
-      // For auth viewers: inject pages nav sidebar for quick article switching
-      let html = result.html;
+    // ETag / 304 handling — skip for share viewers because post-cache
+    // injections (editable flag, viewer attr) are not reflected in the ETag.
+    const wrapperEtag = isHtmlArtifact ? `"${result.etag.replace(/"/g, '')}-wrapped"` : result.etag;
+    if (!isShareViewer) {
+      const clientEtag = req.headers['if-none-match'];
+      if (clientEtag && clientEtag === wrapperEtag) {
+        logger.info('page served', { path: slug, status: 304, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: 'auth', type: result.type });
+        return res.status(304).end();
+      }
+      res.setHeader('ETag', wrapperEtag);
+      res.setHeader('Cache-Control', 'public, max-age=60');
+    } else {
+      res.setHeader('Cache-Control', 'no-store');
+    }
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+
+    if (isHtmlArtifact) {
+      const titleMatch = result.html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+      const title = titleMatch ? titleMatch[1].replace(/\s+/g, ' ').trim() : slug;
+      const iframeSrc = browserPath(browserBase, `${displaySlug}?raw=1`);
+      let html = htmlArtifactTemplate({ title, baseUrl: browserBase, slug: displaySlug, iframeSrc });
       if (isShareViewer) {
         html = injectShareViewer(html, { canWriteAttachments: shareCanWriteAttachments });
+        html = await finalizeShareHtml(html, { config, browserBase, displaySlug, share: shareContext || res.locals.shareContext });
       } else {
         const pages = await scanPages(config.contentDir);
         html = injectNavSidebar(html, pages, displaySlug, browserBase);
       }
-
-      logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth' });
-      res.send(html);
-    } catch (err) {
-      const elapsed = Math.round(performance.now() - start);
-
-      if (err.code === 'ENOENT') {
-        logger.info('page not found', { path: slug, render_ms: elapsed });
-        res.status(404).send(notFoundTemplate(slug, browserBase));
-        return;
-      }
-
-      if (err.statusCode) {
-        logger.warn('page error', { path: slug, status: err.statusCode, err: err.message, render_ms: elapsed });
-        res.status(err.statusCode).send(errorTemplate(err.message, browserBase));
-        return;
-      }
-
-      logger.error('page render failed', { path: slug, err: err.message, render_ms: elapsed });
-      res.status(500).send(errorTemplate('An error occurred while rendering this page.', browserBase));
+      logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth', type: result.type });
+      return res.send(html);
     }
+
+    let html = result.html;
+    if (isShareViewer) {
+      html = injectShareViewer(html, { canWriteAttachments: shareCanWriteAttachments });
+      html = await finalizeShareHtml(html, { config, browserBase, displaySlug, share: shareContext || res.locals.shareContext });
+    } else {
+      const pages = await scanPages(config.contentDir);
+      html = injectNavSidebar(html, pages, displaySlug, browserBase);
+    }
+
+    logger.info('page served', { path: slug, status: 200, cache_hit: result.cacheHit, singleflight_shared: result.singleflightShared, render_ms: elapsed, viewer: isShareViewer ? 'share' : 'auth' });
+    res.send(html);
+  } catch (err) {
+    const elapsed = Math.round(performance.now() - start);
+
+    if (err.code === 'ENOENT') {
+      logger.info('page not found', { path: slug, render_ms: elapsed });
+      res.status(404).send(notFoundTemplate(slug, browserBase));
+      return;
+    }
+
+    if (err.statusCode) {
+      logger.warn('page error', { path: slug, status: err.statusCode, err: err.message, render_ms: elapsed });
+      res.status(err.statusCode).send(errorTemplate(err.message, browserBase));
+      return;
+    }
+
+    logger.error('page render failed', { path: slug, err: err.message, render_ms: elapsed });
+    res.status(500).send(errorTemplate('An error occurred while rendering this page.', browserBase));
+  }
+}
+
+export async function renderSharePage(req, res, { slug, config, browserBase, share }) {
+  res.locals.viewerType = 'share';
+  res.locals.authenticated = false;
+  res.locals.shareSlug = share.slug;
+  res.locals.shareCanWriteAttachments = share.canWriteAttachments === true;
+  res.locals.shareContext = share;
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Referrer-Policy', 'no-referrer');
+  return renderPageSlug({ req, res, config, browserBase, rawSlug: slug, shareContext: share });
+}
+
+/**
+ * Route handler for GET /:slug(*)
+ */
+export function pageRoute(config) {
+  return async (req, res) => {
+    const browserBase = browserBaseFromRequest(req);
+    const rawSlug = req.params.slug || req.params[0] || req.path.slice(1) || '';
+    return renderPageSlug({ req, res, config, browserBase, rawSlug });
   };
 }

--- a/src/routes/share-api.js
+++ b/src/routes/share-api.js
@@ -8,7 +8,6 @@
 import {
   createShare,
   createShareAccessCookie,
-  createShareScopeCookie,
   getActiveShare,
   revokeShare,
   revokeAllForSlug,
@@ -17,6 +16,7 @@ import {
 } from '../sharing/share-manager.js';
 import { logger } from '../utils/logger.js';
 import { browserBaseFromRequest, browserPath } from '../lib/browser-base.js';
+import { renderSharePage } from './pages.js';
 
 /**
  * CSRF validation via Origin/Referer headers (same approach as logout).
@@ -96,9 +96,9 @@ function appendSetCookie(res, cookie) {
  * @param {Express} app
  * @param {object} sharingConfig - { allowPermanent }
  */
-export function setupShareApi(app, sharingConfig) {
-  // GET /s/:tokenId — short share link redirect
-  app.get('/s/:tokenId', (req, res) => {
+export function setupShareApi(app, sharingConfig, config = {}) {
+  // GET /s/:tokenId — short share link rendered in place
+  app.get('/s/:tokenId', async (req, res, next) => {
     const share = getActiveShare(req.params.tokenId);
     if (!share) {
       return res.status(404).send('Share not found');
@@ -106,11 +106,18 @@ export function setupShareApi(app, sharingConfig) {
 
     const browserBase = browserBaseFromRequest(req);
     const accessCookie = createShareAccessCookie(share.slug, share.tokenId, share.expiresAt);
-    const scopeCookie = createShareScopeCookie(share.slug, share.tokenId, share.expiresAt);
     appendSetCookie(res, accessCookie.header);
-    appendSetCookie(res, scopeCookie.header);
     res.setHeader('Cache-Control', 'no-store');
-    res.redirect(302, browserPath(browserBase, share.slug));
+    try {
+      await renderSharePage(req, res, {
+        slug: share.slug,
+        config,
+        browserBase,
+        share,
+      });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // POST /api/share — create a share link

--- a/src/security/auth.js
+++ b/src/security/auth.js
@@ -13,10 +13,8 @@ import {
   clearShareAccessCookieHeader,
   clearShareScopeCookieHeader,
   createShareAccessCookie,
-  createShareScopeCookie,
   verifyShare,
   verifyShareAccessCookie,
-  verifyShareScopeCookie,
 } from '../sharing/share-manager.js';
 import { browserBaseFromRequest, browserPath, browserRoot, isPathWithinBase } from '../lib/browser-base.js';
 import { isAssetExtension } from '../utils/mime.js';
@@ -178,11 +176,6 @@ function getSessionCookie(req) {
   return cookies[COOKIE_NAME] || null;
 }
 
-function getShareScopeCookie(req) {
-  const cookies = parseCookies(req.headers.cookie);
-  return cookies[SHARE_SCOPE_COOKIE_NAME] || null;
-}
-
 function getShareAccessCookie(req) {
   const cookies = parseCookies(req.headers.cookie);
   return cookies[SHARE_ACCESS_COOKIE_NAME] || null;
@@ -220,11 +213,6 @@ function clearShareAccessCookie(res) {
   appendSetCookie(res, clearShareAccessCookieHeader());
 }
 
-function setShareScopeCookie(res, slug, tokenId, tokenExpiresAt) {
-  const cookie = createShareScopeCookie(slug, tokenId, tokenExpiresAt);
-  appendSetCookie(res, cookie.header);
-}
-
 function setShareAccessCookie(res, slug, tokenId, tokenExpiresAt) {
   const cookie = createShareAccessCookie(slug, tokenId, tokenExpiresAt);
   appendSetCookie(res, cookie.header);
@@ -235,11 +223,9 @@ function acceptShareViewer(res, result, options = {}) {
   res.locals.authenticated = false;
   res.locals.shareSlug = result.slug;
   res.locals.shareCanWriteAttachments = result.canWriteAttachments === true;
+  res.locals.shareContext = result;
   if (options.refreshAccessCookie) {
     setShareAccessCookie(res, result.slug, result.tokenId, result.expiresAt);
-  }
-  if (options.refreshScopeCookie) {
-    setShareScopeCookie(res, result.slug, result.tokenId, result.expiresAt);
   }
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Referrer-Policy', 'no-referrer');
@@ -594,7 +580,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       const slug = req.path.slice(1);
       const result = verifyShareAccessCookie(getShareAccessCookie(req), slug);
       if (result.valid) {
-        acceptShareViewer(res, result, { refreshScopeCookie: true });
+        acceptShareViewer(res, result);
         return next();
       }
     }
@@ -608,7 +594,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       const slug = req.path.slice(1);
       const result = verifyShare(req.query.token, slug);
       if (result.valid) {
-        acceptShareViewer(res, result, { refreshAccessCookie: true, refreshScopeCookie: true });
+        acceptShareViewer(res, result, { refreshAccessCookie: true });
         return next();
       }
       logger.info('share token invalid', { path: req.path, ip: getClientIp(req) });
@@ -639,16 +625,11 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       logger.info('api share token invalid', { path: req.path, ip: getClientIp(req) });
     }
 
-    if ((req.method === 'GET' || req.method === 'HEAD') && isAssetPath(req.path)) {
-      const result = verifyShareScopeCookie(getShareScopeCookie(req), req.path.slice(1));
-      if (result.valid) {
-        res.locals.viewerType = 'share';
-        res.locals.authenticated = false;
-        res.setHeader('Cache-Control', 'no-store');
-        res.setHeader('Referrer-Policy', 'no-referrer');
-        return next();
-      }
-      logger.info('asset share-scope cookie invalid', { path: req.path, ip: getClientIp(req) });
+    if ((req.method === 'GET' || req.method === 'HEAD')
+        && req.path.startsWith('/assets/')
+        && typeof req.query.exp === 'string'
+        && typeof req.query.sig === 'string') {
+      return next();
     }
 
     if (validateSession(getSessionCookie(req))) {

--- a/src/sharing/share-manager.js
+++ b/src/sharing/share-manager.js
@@ -15,6 +15,7 @@ const TOKEN_ID_BYTES = 16;
 const SHARE_ACCESS_BYTES = 32;
 const SHARE_SESSION_MAX_AGE_SECONDS = 3600;
 const SHARE_SCOPE_MAX_AGE_SECONDS = 3600;
+const SHARE_ASSET_MAX_AGE_MS = 3600_000;
 
 export const SHARE_ACCESS_COOKIE_NAME = '__Host-share_access';
 export const SHARE_SCOPE_COOKIE_NAME = '__Host-share_scope';
@@ -253,6 +254,12 @@ function computeShareScopeHmac(directory, tokenId, expiresAt, secret) {
     .digest('hex');
 }
 
+function computeShareAssetHmac(uri, realPath, expiresAt, tokenId, secret) {
+  return crypto.createHmac('sha256', Buffer.from(secret, 'hex'))
+    .update(`${normalizeSlug(uri)}|${realPath}|${expiresAt}|${tokenId}`)
+    .digest('hex');
+}
+
 function isAssetWithinScope(assetPath, directory) {
   const normalizedAsset = normalizeSlug(assetPath);
   const assetDir = directoryScope(normalizedAsset);
@@ -431,6 +438,47 @@ export function verifyShareScopeCookie(cookieValue, assetPath) {
   }
 
   return { valid: true, directory, viewerType: 'share' };
+}
+
+export function shareAssetExpiresAt(shareExpiresAt) {
+  const current = nowMs();
+  const cap = current + SHARE_ASSET_MAX_AGE_MS;
+  if (!shareExpiresAt || shareExpiresAt === 0) return cap;
+  return Math.max(0, Math.min(cap, Number(shareExpiresAt)));
+}
+
+export function createShareAssetSignature({ uri, realPath, expiresAt, tokenId }) {
+  if (!isTokenId(tokenId) || !Number.isFinite(Number(expiresAt))) {
+    throw new Error('Invalid share asset signature input');
+  }
+  const hmac = computeShareAssetHmac(uri, realPath, Number(expiresAt), tokenId, getSecret());
+  return `${tokenId}.${hmac}`;
+}
+
+export function verifyShareAssetSignature({ uri, realPath, expiresAt, tokenId, sig }) {
+  const exp = Number(expiresAt);
+  if (!Number.isFinite(exp) || !sig || typeof sig !== 'string') {
+    return { valid: false };
+  }
+  let actualSig = sig;
+  let actualTokenId = tokenId;
+  const dotIndex = sig.indexOf('.');
+  if (dotIndex !== -1) {
+    actualTokenId = sig.slice(0, dotIndex);
+    actualSig = sig.slice(dotIndex + 1);
+  }
+  if (!isTokenId(actualTokenId)) return { valid: false };
+  if (nowMs() > exp) return { valid: false };
+  const record = activeShareRecord(actualTokenId);
+  if (!record || normalizeSlug(record.slug) !== normalizeSlug(uri)) return { valid: false };
+  if (record.expiresAt !== 0 && exp > record.expiresAt) return { valid: false };
+
+  const expected = computeShareAssetHmac(uri, realPath, exp, actualTokenId, getSecret());
+  const actualBuffer = Buffer.from(actualSig, 'hex');
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  if (actualBuffer.length !== expectedBuffer.length) return { valid: false };
+  if (!crypto.timingSafeEqual(actualBuffer, expectedBuffer)) return { valid: false };
+  return { valid: true, share: record };
 }
 
 export function revokeShare(tokenId) {

--- a/test/asset-route.test.js
+++ b/test/asset-route.test.js
@@ -11,17 +11,14 @@ process.env.PAGES_DATA_DIR = dataDir;
 const express = (await import('express')).default;
 const { initCache } = await import('../src/cache/pageCache.js');
 const { setupAssetRoute } = await import('../src/routes/asset.js');
+const { adminRoute } = await import('../src/routes/admin.js');
+const { setupLogicalAssetRoute } = await import('../src/routes/logical-assets.js');
 const { pageRoute } = await import('../src/routes/pages.js');
 const { setupShareApi } = await import('../src/routes/share-api.js');
 const { setupStateApi } = await import('../src/routes/state-api.js');
 const { setupAuth, hashPassword } = await import('../src/security/auth.js');
 const { securityHeaders } = await import('../src/security/headers.js');
-const {
-  SHARE_SCOPE_COOKIE_NAME,
-  createShare,
-  createShareScopeCookie,
-  revokeShare,
-} = await import('../src/sharing/share-manager.js');
+const { SHARE_SCOPE_COOKIE_NAME, createShare, createShareScopeCookie, revokeShare } = await import('../src/sharing/share-manager.js');
 
 test.after(async () => {
   await rm(dataDir, { recursive: true, force: true });
@@ -50,9 +47,10 @@ async function withServer(config, fn) {
   const app = express();
   app.use(securityHeaders());
   setupAuth(app, config.auth || { enabled: false, password: null });
-  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false });
+  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false }, config);
   setupStateApi(app);
   app.get('/', (_req, res) => res.send('root'));
+  setupLogicalAssetRoute(app, config);
   setupAssetRoute(app, config);
   app.get('/:slug(*)', pageRoute(config));
   app.use((err, req, res, _next) => {
@@ -103,6 +101,12 @@ function cookieHeader(setCookieHeader) {
     .split(/,\s*(?=__Host-)/)
     .map(cookie => cookie.split(';', 1)[0])
     .join('; ');
+}
+
+function signedAssetPath(html, assetName) {
+  const match = html.match(new RegExp(`["']([^"']*/assets/[^"']*path=[^"']*${assetName}[^"']*)["']`));
+  assert.ok(match, `signed asset URL for ${assetName} should be present`);
+  return match[1].replace(/&amp;/g, '&');
 }
 
 function expectLoginRedirect(response) {
@@ -173,6 +177,41 @@ test('asset route serves allowlisted assets with MIME, ETag, 304, and size limit
   }
 });
 
+test('root route serves admin console and /admin is not mounted', async () => {
+  const contentDir = await makeContentDir();
+  try {
+    const config = baseConfig(contentDir);
+    const app = express();
+    app.get('/', adminRoute());
+    setupLogicalAssetRoute(app, config);
+    setupAssetRoute(app, config);
+    app.get('/:slug(*)', pageRoute(config));
+    app.use((err, req, res, _next) => {
+      const status = err.statusCode || err.status || 500;
+      res.status(status >= 400 && status < 500 ? status : 500).send(err.message || 'Internal Server Error');
+    });
+    const server = await new Promise((resolve) => {
+      const s = http.createServer(app);
+      s.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    try {
+      const root = await fetch(`${origin}/`);
+      assert.equal(root.status, 200);
+      assert.match(await root.text(), /id="pages-admin-root"/);
+
+      const oldAdmin = await fetch(`${origin}/admin`, { redirect: 'manual' });
+      assert.equal(oldAdmin.status, 404);
+    } finally {
+      await new Promise((resolve, reject) => {
+        server.close((err) => err ? reject(err) : resolve());
+      });
+    }
+  } finally {
+    await rm(contentDir, { recursive: true, force: true });
+  }
+});
+
 test('asset route follows auth wall, session auth, and method boundaries', async () => {
   const contentDir = await makeContentDir();
   try {
@@ -195,7 +234,7 @@ test('asset route follows auth wall, session auth, and method boundaries', async
   }
 });
 
-test('share page access sets scoped cookie and asset request uses cookie without token', async () => {
+test('share page access renders in place and signs referenced assets', async () => {
   const contentDir = await makeContentDir();
   try {
     await writeFile(path.join(contentDir, 'renovation-checklist.html'), '<!doctype html><img src="kitchen-ref.jpg">');
@@ -208,24 +247,21 @@ test('share page access sets scoped cookie and asset request uses cookie without
 
     await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
       const redirect = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
-      assert.equal(redirect.status, 302);
-      assert.equal(redirect.headers.get('location'), '/renovation-checklist');
-      assert.doesNotMatch(redirect.headers.get('location'), /token=/);
-
-      const page = await fetch(`${origin}/renovation-checklist`, {
-        headers: { Cookie: cookieHeader(redirect.headers.get('set-cookie')) },
-      });
-      assert.equal(page.status, 200);
+      assert.equal(redirect.status, 200);
+      assert.equal(redirect.headers.get('location'), null);
+      const body = await redirect.text();
+      assert.match(body, /<base href="\/renovation-checklist">/);
       const setCookie = redirect.headers.get('set-cookie');
-      assert.match(setCookie, /__Host-share_scope=/);
+      assert.match(setCookie, /__Host-share_access=/);
+      assert.doesNotMatch(setCookie, /__Host-share_scope=/);
       assert.match(setCookie, /HttpOnly/);
       assert.match(setCookie, /Secure/);
       assert.match(setCookie, /SameSite=Lax/);
       assert.match(setCookie, /Path=\//);
       assert.match(setCookie, /Max-Age=\d+/);
-      const cookie = shareScopeCookie(setCookie);
 
-      let res = await fetch(`${origin}/kitchen-ref.jpg`, { headers: { Cookie: cookie } });
+      const signedPath = signedAssetPath(body, 'kitchen-ref.jpg');
+      let res = await fetch(`${origin}${signedPath}`);
       assert.equal(res.status, 200);
       assert.equal(await res.text(), 'kitchen image');
       assert.equal(res.headers.get('cache-control'), 'no-store');
@@ -238,7 +274,7 @@ test('share page access sets scoped cookie and asset request uses cookie without
 
       res = await fetch(`${origin}/docs/nested.jpg`, {
         redirect: 'manual',
-        headers: { Cookie: cookie },
+        headers: { Cookie: cookieHeader(setCookie) },
       });
       expectAssetDenied(res);
     });
@@ -247,13 +283,16 @@ test('share page access sets scoped cookie and asset request uses cookie without
   }
 });
 
-test('nested share-scope cookie isolates root and sibling directory assets', async () => {
+test('signed share assets allow page assets while isolating unsigned siblings', async () => {
   const contentDir = await makeContentDir();
   try {
     await mkdir(path.join(contentDir, 'docs'));
     await mkdir(path.join(contentDir, 'other'));
-    await writeFile(path.join(contentDir, 'docs', 'guide.html'), '<!doctype html><img src="diagram.png">');
+    await mkdir(path.join(contentDir, 'shared'));
+    await writeFile(path.join(contentDir, 'docs', 'guide.html'), '<!doctype html><img src="diagram.png"><img src="../shared/logo.png">');
     await writeFile(path.join(contentDir, 'docs', 'diagram.png'), 'diagram');
+    await writeFile(path.join(contentDir, 'shared', 'logo.png'), 'logo');
+    await writeFile(path.join(contentDir, 'shared', 'secret.png'), 'secret');
     await writeFile(path.join(contentDir, 'root.png'), 'root');
     await writeFile(path.join(contentDir, 'other', 'secret.png'), 'secret');
     const token = createShare('docs/guide', '24h', { allowPermanent: false }).token;
@@ -261,15 +300,25 @@ test('nested share-scope cookie isolates root and sibling directory assets', asy
     await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
       const page = await fetch(`${origin}/docs/guide?token=${encodeURIComponent(token)}`);
       assert.equal(page.status, 200);
-      const cookie = shareScopeCookie(page.headers.get('set-cookie'));
+      const body = await page.text();
+      const signedPath = signedAssetPath(body, 'diagram.png');
+      const sharedPath = signedAssetPath(body, 'logo.png');
 
-      let res = await fetch(`${origin}/docs/diagram.png`, { headers: { Cookie: cookie } });
+      let res = await fetch(`${origin}${signedPath}`);
       assert.equal(res.status, 200);
 
-      res = await fetch(`${origin}/root.png`, { redirect: 'manual', headers: { Cookie: cookie } });
+      res = await fetch(`${origin}${sharedPath}`);
+      assert.equal(res.status, 200);
+      assert.equal(await res.text(), 'logo');
+
+      const tamperedPath = sharedPath.replace('logo.png', 'secret.png');
+      res = await fetch(`${origin}${tamperedPath}`, { redirect: 'manual' });
+      assert.equal(res.status, 403);
+
+      res = await fetch(`${origin}/root.png`, { redirect: 'manual' });
       expectAssetDenied(res);
 
-      res = await fetch(`${origin}/other/secret.png`, { redirect: 'manual', headers: { Cookie: cookie } });
+      res = await fetch(`${origin}/other/secret.png`, { redirect: 'manual' });
       expectAssetDenied(res);
     });
   } finally {
@@ -306,7 +355,7 @@ test('expired and tampered share-scope cookies fall through to auth wall', async
   }
 });
 
-test('revoked share invalidates existing share-scope asset cookie', async () => {
+test('revoked share invalidates existing signed asset URLs', async () => {
   const contentDir = await makeContentDir();
   try {
     await writeFile(path.join(contentDir, 'shared.html'), '<!doctype html><img src="asset.jpg">');
@@ -316,17 +365,16 @@ test('revoked share invalidates existing share-scope asset cookie', async () => 
     await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
       const page = await fetch(`${origin}/shared?token=${encodeURIComponent(share.token)}`);
       assert.equal(page.status, 200);
-      const cookie = shareScopeCookie(page.headers.get('set-cookie'));
+      const signedPath = signedAssetPath(await page.text(), 'asset.jpg');
 
-      let res = await fetch(`${origin}/asset.jpg`, { headers: { Cookie: cookie } });
+      let res = await fetch(`${origin}${signedPath}`);
       assert.equal(res.status, 200);
 
       assert.equal(revokeShare(share.tokenId), true);
-      res = await fetch(`${origin}/asset.jpg`, {
+      res = await fetch(`${origin}${signedPath}`, {
         redirect: 'manual',
-        headers: { Cookie: cookie },
       });
-      expectAssetDenied(res);
+      assert.equal(res.status, 403);
     });
   } finally {
     await rm(contentDir, { recursive: true, force: true });
@@ -359,15 +407,16 @@ test('asset route rejects traversal, null byte, and double-encoded traversal', a
   }
 });
 
-test('login clears share-scope cookie without overwriting session cookie', async () => {
+test('login clears legacy share-scope cookie without overwriting session cookie', async () => {
   const contentDir = await makeContentDir();
   try {
     await writeFile(path.join(contentDir, 'shared.html'), '<!doctype html><h1>Shared</h1>');
     const token = createShare('shared', '24h', { allowPermanent: false }).token;
 
     await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
-      const page = await fetch(`${origin}/shared?token=${encodeURIComponent(token)}`);
-      const shareCookie = shareScopeCookie(page.headers.get('set-cookie'));
+      await fetch(`${origin}/shared?token=${encodeURIComponent(token)}`);
+      const legacy = createShareScopeCookie('shared', createShare('shared', '24h', { allowPermanent: false }).tokenId, Date.now() + 3600_000).value;
+      const shareCookie = `${SHARE_SCOPE_COOKIE_NAME}=${legacy}`;
       const loginCookies = await login(origin, { Cookie: shareCookie });
       assert.match(loginCookies, /__Host-zylos_pages_session=/);
       assert.match(loginCookies, /__Host-share_scope=;/);

--- a/test/attachment-api.test.js
+++ b/test/attachment-api.test.js
@@ -48,7 +48,7 @@ function baseConfig(contentDir, auth = authConfig(), extra = {}) {
 async function withServer(config, fn, options = {}) {
   const app = express();
   setupAuth(app, config.auth || { enabled: false, password: null }, config.sharing || { enabled: true, allowPermanent: false });
-  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false });
+  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false }, config);
   setupAttachmentApi(app, config, options);
   app.get('/s/:slug', (_req, res) => res.status(200).send('fallback'));
   app.get('/:slug(*)', (req, res) => res.status(200).send(req.params.slug || 'root'));
@@ -283,7 +283,7 @@ test('share viewers can list and read matching artifact attachments but cannot m
       const attachment = (await uploaded.json()).attachment;
 
       let res = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
-      assert.equal(res.status, 302);
+      assert.equal(res.status, 200);
       const shareCookies = cookieHeader(res.headers.get('set-cookie'));
 
       res = await fetch(`${origin}/api/attachments/renovation-checklist/share-log`, {
@@ -328,7 +328,7 @@ test('short share viewers remain read-only even when write permission is request
     const share = createShare('renovation-checklist', '24h', { allowPermanent: false }, { canWriteAttachments: true });
     await withServer(baseConfig(contentDir), async ({ origin }) => {
       let res = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
-      assert.equal(res.status, 302);
+      assert.equal(res.status, 200);
       const shareCookies = cookieHeader(res.headers.get('set-cookie'));
 
       res = await upload(origin, 'renovation-checklist', 'editable-log', shareCookies);
@@ -367,7 +367,7 @@ test('existing short share cookie sessions cannot be upgraded to attachment writ
 
       const readOnly = createShare('renovation-checklist', '24h', { allowPermanent: false });
       let res = await fetch(`${origin}/s/${readOnly.tokenId}`, { redirect: 'manual' });
-      assert.equal(res.status, 302);
+      assert.equal(res.status, 200);
       const readOnlyCookies = cookieHeader(res.headers.get('set-cookie'));
 
       res = await upload(origin, 'renovation-checklist', 'short-upgrade-before', readOnlyCookies);

--- a/test/html-artifacts.test.js
+++ b/test/html-artifacts.test.js
@@ -55,7 +55,7 @@ async function withServer(config, fn) {
   const app = express();
   app.use(securityHeaders());
   setupAuth(app, config.auth || { enabled: false, password: null });
-  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false });
+  setupShareApi(app, config.sharing || { enabled: true, allowPermanent: false }, config);
   setupRawApi(app, config);
   app.get('/', indexRoute(config));
   app.get('/:slug(*)', pageRoute(config));

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -26,7 +26,16 @@ function cookieHeader(setCookie) {
 }
 
 function makeServer({ auth = false, sharingEnabled = true, shareViewer = false } = {}) {
+  const contentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-pages-share-content-'));
+  fs.mkdirSync(path.join(contentDir, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(contentDir, 'docs', 'page.html'), '<!doctype html><head><title>Shared page</title></head><h1>Shared page</h1>');
   const app = express();
+  const config = {
+    contentDir,
+    security: { allowRawHtml: false, maxFileSizeBytes: 1024 * 1024, renderTimeoutMs: 5000 },
+    toc: { minHeadings: 3 },
+    theme: { codeTheme: 'github-dark' },
+  };
   if (auth) {
     setupAuth(app, {
       enabled: true,
@@ -40,7 +49,7 @@ function makeServer({ auth = false, sharingEnabled = true, shareViewer = false }
     });
   }
   if (sharingEnabled) {
-    setupShareApi(app, { enabled: true, allowPermanent: false });
+    setupShareApi(app, { enabled: true, allowPermanent: false }, config);
   }
   app.get('/docs/page', (req, res) => {
     if (req.query.locals === '1') {
@@ -59,7 +68,7 @@ function makeServer({ auth = false, sharingEnabled = true, shareViewer = false }
   return new Promise((resolve) => {
     server.listen(0, '127.0.0.1', () => {
       const { port } = server.address();
-      resolve({ server, origin: `http://127.0.0.1:${port}` });
+      resolve({ server, origin: `http://127.0.0.1:${port}`, contentDir });
     });
   });
 }
@@ -241,7 +250,7 @@ test('patch rejects revoked expired malformed unknown and deprecated write share
   }
 });
 
-test('short share URL sets share cookies and redirects to clean page URL', async () => {
+test('short share URL sets access cookie and renders clean page in place', async () => {
   const { server, origin } = await makeServer();
   try {
     const create = await fetch(`${origin}/api/share`, {
@@ -256,12 +265,12 @@ test('short share URL sets share cookies and redirects to clean page URL', async
     const share = await create.json();
 
     const redirect = await fetch(share.url, { redirect: 'manual' });
-    assert.equal(redirect.status, 302);
-    assert.equal(redirect.headers.get('location'), '/docs/page');
+    assert.equal(redirect.status, 200);
+    assert.equal(redirect.headers.get('location'), null);
     const setCookie = redirect.headers.get('set-cookie');
     assert.match(setCookie, /__Host-share_access=/);
-    assert.match(setCookie, /__Host-share_scope=/);
-    assert.doesNotMatch(redirect.headers.get('location'), /token=/);
+    assert.doesNotMatch(setCookie, /__Host-share_scope=/);
+    assert.match(await redirect.text(), /<base href="\/docs\/page">/);
   } finally {
     server.close();
   }
@@ -292,11 +301,10 @@ test('auth middleware allows short share URL cookies to access target page', asy
     assert.equal(create.status, 200);
     const share = await create.json();
 
-    const redirect = await fetch(share.url, { redirect: 'manual' });
-    assert.equal(redirect.status, 302);
-    assert.doesNotMatch(redirect.headers.get('location'), /login/);
-    assert.equal(redirect.headers.get('location'), '/docs/page');
-    const cookies = cookieHeader(redirect.headers.get('set-cookie'));
+    const direct = await fetch(share.url, { redirect: 'manual' });
+    assert.equal(direct.status, 200);
+    assert.doesNotMatch(await direct.text(), /login/);
+    const cookies = cookieHeader(direct.headers.get('set-cookie'));
 
     const page = await fetch(`${origin}/docs/page`, {
       redirect: 'manual',
@@ -333,9 +341,9 @@ test('auth middleware keeps short share cookies read-only', async () => {
     assert.equal(create.status, 200);
     const share = await create.json();
 
-    const redirect = await fetch(share.url, { redirect: 'manual' });
-    assert.equal(redirect.status, 302);
-    const cookies = cookieHeader(redirect.headers.get('set-cookie'));
+    const direct = await fetch(share.url, { redirect: 'manual' });
+    assert.equal(direct.status, 200);
+    const cookies = cookieHeader(direct.headers.get('set-cookie'));
 
     const appCheck = await fetch(`${origin}/docs/page?locals=1`, {
       headers: { Cookie: cookies },

--- a/test/state-api.test.js
+++ b/test/state-api.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
@@ -45,12 +45,24 @@ async function withApp(app, fn) {
 }
 
 async function withServer(authConfig, fn) {
+  const contentDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-state-content-'));
+  await writeFile(path.join(contentDir, 'short-state.html'), '<!doctype html><h1>Short state</h1>');
   const app = express();
+  const config = {
+    contentDir,
+    security: { allowRawHtml: false, maxFileSizeBytes: 1024 * 1024, renderTimeoutMs: 5000 },
+    toc: { minHeadings: 3 },
+    theme: { codeTheme: 'github-dark' },
+  };
   setupAuth(app, authConfig || { enabled: false, password: null });
-  setupShareApi(app, { enabled: true, allowPermanent: false });
+  setupShareApi(app, { enabled: true, allowPermanent: false }, config);
   setupStateApi(app);
   app.get('/', (_req, res) => res.send('root'));
-  await withApp(app, fn);
+  try {
+    await withApp(app, fn);
+  } finally {
+    await rm(contentDir, { recursive: true, force: true });
+  }
 }
 
 async function login(origin) {
@@ -291,9 +303,9 @@ test('state API allows short-share cookie CRUD for the matching artifact', async
 
   await withServer(authConfig(), async ({ origin }) => {
     const redirect = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
-    assert.equal(redirect.status, 302);
-    assert.equal(redirect.headers.get('location'), '/short-state');
-    assert.doesNotMatch(redirect.headers.get('location'), /token=/);
+    assert.equal(redirect.status, 200);
+    assert.equal(redirect.headers.get('location'), null);
+    assert.match(await redirect.text(), /<base href="\/short-state">/);
     const cookies = cookieHeader(redirect.headers.get('set-cookie'));
 
     let res = await fetch(`${origin}/api/state/short-state`, {


### PR DESCRIPTION
## Summary
- Serve the authenticated admin console at `/` and stop mounting `/admin`.
- Render `/s/:tokenId` directly with `<base href>` instead of redirecting to the target page.
- Replace share-scope asset access with per-asset signed `/assets/:uri?path=&exp=&sig=` URLs, including allowed-root cross-directory references and revoke/expiry validation.
- Update share/state/attachment tests for direct share rendering and signed assets.

## Validation
- `npm test`
- `npm run build:admin`
- `git diff --check`
