### PR TITLE
fix: make Pages CLI share base configurable

### DIFF
--- a/references/pages-cli.md
+++ b/references/pages-cli.md
@@ -37,6 +37,7 @@ node src/cli/pages.js unshare reports/q3
 
 - `share` accepts `24h`, `7d`, `30d`, or `permanent` when config allows permanent shares.
 - Registered logical pages are shared as `p/<uri>` and return `/pages/s/<tokenId>`.
+- Share link base URL priority is `PAGES_BASE_URL` env var, then `publicBaseUrl` in `config.json`, then the neutral `/pages` path fallback.
 - `shares` lists active share tokens for the page.
 - `unshare` revokes all active shares for the page.
 

--- a/src/cli/pages.js
+++ b/src/cli/pages.js
@@ -137,8 +137,9 @@ function getPageUrl(uri) {
   return `/pages/p/${uri}`;
 }
 
-function getBaseUrl() {
-  return (process.env.PAGES_BASE_URL || 'https://zylos01.jinglever.com/pages').replace(/\/$/, '');
+function getBaseUrl(config = getConfig()) {
+  const configured = process.env.PAGES_BASE_URL || config.publicBaseUrl || '/pages';
+  return String(configured).replace(/\/$/, '');
 }
 
 function staticPageExists(uri, config) {
@@ -160,13 +161,13 @@ function shareSlugForUri(uri, config, options = {}) {
   return normalized;
 }
 
-function formatShare(share) {
+function formatShare(share, config = getConfig()) {
   return {
     tokenId: share.tokenId,
     expiresAt: share.expiresAt,
     createdAt: share.createdAt,
     canWriteAttachments: share.canWriteAttachments === true,
-    shortUrl: `${getBaseUrl()}/s/${share.tokenId}`,
+    shortUrl: `${getBaseUrl(config)}/s/${share.tokenId}`,
   };
 }
 
@@ -278,14 +279,15 @@ function commandShare(args) {
     tokenId: result.tokenId,
     expiresAt: result.expiresAt,
     canWriteAttachments: result.canWriteAttachments,
-    shortUrl: `${getBaseUrl()}/s/${result.tokenId}`,
+    shortUrl: `${getBaseUrl(config)}/s/${result.tokenId}`,
   }, args.json);
 }
 
 function commandShares(args) {
   const uri = normalizeUri(args._[0] || args.uri || args.slug);
-  const slug = shareSlugForUri(uri, getConfig());
-  const shares = listSharesForSlug(slug).map(formatShare);
+  const config = getConfig();
+  const slug = shareSlugForUri(uri, config);
+  const shares = listSharesForSlug(slug).map(share => formatShare(share, config));
   output({ ok: true, command: 'shares', uri, slug, shares }, args.json);
 }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -16,6 +16,7 @@ export const CONFIG_PATH = path.join(DATA_DIR, 'config.json');
 export const DEFAULT_CONFIG = {
   enabled: true,
   port: 3462,
+  publicBaseUrl: null,
   contentDir: path.join(HOME, 'zylos/http/public/pages'),
   theme: {
     colorScheme: 'auto',

--- a/test/external-files.test.js
+++ b/test/external-files.test.js
@@ -33,6 +33,7 @@ function makeFixture(options = {}) {
   fs.mkdirSync(contentDir, { recursive: true });
   fs.mkdirSync(sourceRoot, { recursive: true });
   fs.writeFileSync(path.join(dataDir, 'config.json'), JSON.stringify({
+    ...(options.publicBaseUrl ? { publicBaseUrl: options.publicBaseUrl } : {}),
     contentDir,
     externalFiles: {
       enabled: options.enabled ?? true,
@@ -131,6 +132,7 @@ test('unified pages CLI registers, shares, lists shares, and unshares logical pa
   assert.equal(share.slug, 'p/recruit/share-target');
   assert.match(share.tokenId, /^[a-f0-9]{32}$/);
   assert.match(share.shortUrl, /\/pages\/s\/[a-f0-9]{32}$/);
+  assert.doesNotMatch(share.shortUrl, /jinglever\.com/);
 
   const shares = runPagesCli(fixture, ['shares', 'recruit/share-target', '--json']);
   assert.deepEqual(shares.shares.map(entry => entry.tokenId), [share.tokenId]);
@@ -141,6 +143,30 @@ test('unified pages CLI registers, shares, lists shares, and unshares logical pa
 
   const after = runPagesCli(fixture, ['shares', 'recruit/share-target', '--json']);
   assert.deepEqual(after.shares, []);
+});
+
+test('pages CLI share base URL uses config when env is absent', () => {
+  const fixture = makeFixture({ publicBaseUrl: 'https://pages.example.test/custom-pages/' });
+  const source = path.join(fixture.sourceRoot, 'configured-base.md');
+  fs.writeFileSync(source, '# Configured Base\n');
+
+  runPagesCli(fixture, [
+    'register',
+    '--component', 'recruit',
+    '--uri', 'recruit/configured-base',
+    '--source', source,
+    '--json',
+  ]);
+
+  const share = runPagesCli(fixture, ['share', 'recruit/configured-base', '--duration', '24h', '--json'], {
+    env: { PAGES_BASE_URL: '' },
+  });
+  assert.match(share.shortUrl, /^https:\/\/pages\.example\.test\/custom-pages\/s\/[a-f0-9]{32}$/);
+
+  const shares = runPagesCli(fixture, ['shares', 'recruit/configured-base', '--json'], {
+    env: { PAGES_BASE_URL: '' },
+  });
+  assert.equal(shares.shares[0].shortUrl, share.shortUrl);
 });
 
 test('allow-root add preserves existing config fields and enables registration from new root', () => {


### PR DESCRIPTION
## Summary
- remove the hardcoded zylos01.jinglever.com Pages CLI share-link fallback
- add config.publicBaseUrl as the config-backed base URL source after PAGES_BASE_URL
- fall back to neutral /pages when neither env nor config is set
- document share base URL priority and cover config/default behavior in CLI tests

## Validation
- npm test -- test/external-files.test.js
- git diff --check
- npm test
- npm run build:admin