### PR TITLE
Fix Pages sidebar to use logical page registry

### DIFF
--- a/src/pages/page-store.js
+++ b/src/pages/page-store.js
@@ -212,6 +212,22 @@ export function searchLogicalPages(query = '') {
   }));
 }
 
+export function listLogicalPagesForNavigation() {
+  initPageStore();
+  const rows = db.prepare(`
+    SELECT * FROM logical_pages
+    ORDER BY uri ASC
+  `).all();
+  return rows.map(record => ({
+    slug: `p/${record.uri}`,
+    title: record.title,
+    description: '',
+    date: new Date(record.updated_at).toISOString().split('T')[0],
+    tags: [],
+    type: record.source_ext === '.html' ? 'html' : 'markdown',
+  }));
+}
+
 export function recordAccessLog({ pageUri, viewerType = 'auth', shareTokenId = null, requestPath = '', status = 200 }) {
   initPageStore();
   db.prepare(`
@@ -241,4 +257,3 @@ export function pruneAccessLogs({ maxAgeDays = 30, maxRows = 10000 } = {}) {
   }
   return { ageDeleted, rowDeleted };
 }
-

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,13 +1,9 @@
 // Directory index route handler
 
-import { readdir, stat, readFile } from 'node:fs/promises';
-import path from 'node:path';
-import matter from 'gray-matter';
 import { indexTemplate } from '../templates/indexTemplate.js';
 import { logger } from '../utils/logger.js';
 import { browserBaseFromRequest } from '../lib/browser-base.js';
 import { buildPageTree } from '../utils/pageTree.js';
-import { resolvePageDescriptor } from '../security/pathGuard.js';
 
 /**
  * Route handler for GET / — lists all available pages.
@@ -35,88 +31,13 @@ export function indexRoute(config) {
 }
 
 /**
- * Recursively scan the content directory for page files.
- * Hides files starting with _ or .
+ * List registered logical pages for navigation.
+ *
+ * The content directory may contain drafts, source artifacts, or historical
+ * bare files, but owner-facing navigation should reflect the logical page
+ * registry, not the filesystem.
  */
-export async function scanPages(contentDir, subdir = '') {
-  const pagesBySlug = new Map();
-  const dirPath = path.join(contentDir, subdir);
-
-  let entries;
-  try {
-    entries = await readdir(dirPath, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  for (const entry of entries) {
-    // Skip hidden and underscore-prefixed files
-    if (entry.name.startsWith('.') || entry.name.startsWith('_')) continue;
-
-    const relativePath = path.join(subdir, entry.name);
-
-    if (entry.isDirectory()) {
-      const subPages = await scanPages(contentDir, relativePath);
-      for (const page of subPages) {
-        pagesBySlug.set(page.slug, page);
-      }
-    } else if (/\.(md|html)$/i.test(entry.name)) {
-      try {
-        const filePath = path.join(contentDir, relativePath);
-        const slug = relativePath.replace(/\.(md|html)$/i, '');
-        const descriptor = await resolvePageDescriptor(slug, contentDir);
-
-        // Same-slug dedup: only the selected descriptor should appear.
-        if (descriptor.filePath !== filePath) continue;
-
-        const content = await readFile(filePath, 'utf-8');
-        const stats = await stat(filePath);
-        let page;
-
-        if (descriptor.type === 'html') {
-          page = {
-            slug,
-            title: inferTitleFromHtml(content) || slug,
-            description: '',
-            date: stats.mtime.toISOString().split('T')[0],
-            tags: [],
-            type: 'html',
-          };
-        } else {
-          const { data } = matter(content);
-
-          // Skip drafts
-          if (data.draft === true) continue;
-
-          page = {
-            slug,
-            title: data.title || inferTitleFromContent(content) || slug,
-            description: data.description || '',
-            date: data.date instanceof Date ? data.date.toISOString().split('T')[0] : (data.date || stats.mtime.toISOString().split('T')[0]),
-            tags: data.tags || [],
-            type: 'markdown',
-          };
-        }
-
-        pagesBySlug.set(slug, page);
-      } catch {
-        // Skip files that can't be read
-      }
-    }
-  }
-
-  const pages = [...pagesBySlug.values()];
-  // Sort by date (newest first)
-  pages.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
-  return pages;
-}
-
-function inferTitleFromContent(content) {
-  const match = content.match(/^#\s+(.+)$/m);
-  return match ? match[1].trim() : null;
-}
-
-function inferTitleFromHtml(content) {
-  const match = content.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
-  return match ? match[1].replace(/\s+/g, ' ').trim() : null;
+export async function scanPages() {
+  const { listLogicalPagesForNavigation } = await import('../pages/page-store.js');
+  return listLogicalPagesForNavigation();
 }

--- a/src/utils/pageTree.js
+++ b/src/utils/pageTree.js
@@ -7,13 +7,14 @@ export function buildPageTree(pages) {
   const folderMap = new Map();
 
   for (const page of pages) {
-    const slashIndex = page.slug.lastIndexOf('/');
+    const treeSlug = page.slug?.startsWith('p/') ? page.slug.slice(2) : page.slug;
+    const slashIndex = treeSlug.lastIndexOf('/');
     if (slashIndex === -1) {
       topLevel.push(page);
       continue;
     }
 
-    const path = page.slug.substring(0, slashIndex);
+    const path = treeSlug.substring(0, slashIndex);
     let folder = folderMap.get(path);
     if (!folder) {
       folder = {

--- a/test/html-artifacts.test.js
+++ b/test/html-artifacts.test.js
@@ -289,17 +289,31 @@ test('raw API returns markdown when both html and markdown exist, and share view
   }
 });
 
-test('scanPages lists html pages and deduplicates same-slug markdown fallback', async () => {
+test('scanPages lists registered logical pages instead of bare content files', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'html-only.html'), '<!doctype html><title>HTML Title</title><h1>HTML</h1>');
-    await writeFile(path.join(contentDir, 'both.md'), '---\ntitle: Markdown Title\n---\n# Markdown\n');
-    await writeFile(path.join(contentDir, 'both.html'), '<!doctype html><title>HTML Priority</title>');
+    const registeredHtml = path.join(contentDir, 'registered.html');
+    const bareHtml = path.join(contentDir, 'bare.html');
+    await writeFile(registeredHtml, '<!doctype html><title>Registered HTML</title><h1>HTML</h1>');
+    await writeFile(bareHtml, '<!doctype html><title>Bare HTML</title>');
+    const { registerLogicalPage } = await import('../src/pages/page-store.js');
+    registerLogicalPage({
+      uri: 'docs/registered',
+      title: 'Registered HTML',
+      sourcePath: registeredHtml,
+      component: 'content',
+    }, {
+      contentDir,
+      externalFiles: {
+        allowedSources: {
+          content: contentDir,
+        },
+      },
+    });
 
     const pages = await scanPages(contentDir);
-    assert.deepEqual(pages.map(page => [page.slug, page.title, page.type]).sort(), [
-      ['both', 'HTML Priority', 'html'],
-      ['html-only', 'HTML Title', 'html'],
+    assert.deepEqual(pages.map(page => [page.slug, page.title, page.type]), [
+      ['p/docs/registered', 'Registered HTML', 'html'],
     ]);
   } finally {
     await rm(contentDir, { recursive: true, force: true });

--- a/test/page-tree.test.js
+++ b/test/page-tree.test.js
@@ -37,30 +37,47 @@ test('buildPageTree sorts folders by path and folder pages by newest date', () =
   assert.deepEqual(tree.folders[1].pages.map(page => page.slug), ['z/new', 'z/old']);
 });
 
-test('scanPages and buildPageTree preserve hidden, draft, and multi-segment behavior', async () => {
+test('scanPages lists only registered logical pages and preserves directory groups', async () => {
   const contentDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-tree-'));
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-tree-db-'));
+  const sourceRoot = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-tree-source-'));
+  process.env.PAGES_DATA_DIR = dataDir;
   try {
-    await writeFile(path.join(contentDir, 'top.md'), '---\ntitle: Top\n---\n# Top\n');
-    await writeFile(path.join(contentDir, '.hidden.md'), '# Hidden\n');
-    await writeFile(path.join(contentDir, '_underscore.md'), '# Underscore\n');
-    await writeFile(path.join(contentDir, 'draft.md'), '---\ndraft: true\n---\n# Draft\n');
-    await mkdir(path.join(contentDir, 'daily-digest'), { recursive: true });
-    await writeFile(path.join(contentDir, 'daily-digest', 'a.md'), '---\ntitle: Daily\n---\n# Daily\n');
-    await mkdir(path.join(contentDir, 'recruit', 'interview-questions'), { recursive: true });
-    await writeFile(path.join(contentDir, 'recruit', 'interview-questions', 'foo.md'), '---\ntitle: Foo\n---\n# Foo\n');
+    const config = {
+      contentDir,
+      externalFiles: {
+        allowedSources: {
+          source: sourceRoot,
+        },
+      },
+    };
+    await writeFile(path.join(contentDir, 'bare.md'), '# Bare filesystem page\n');
+    await writeFile(path.join(sourceRoot, 'top.md'), '# Top\n');
+    await mkdir(path.join(sourceRoot, 'daily-digest'), { recursive: true });
+    await writeFile(path.join(sourceRoot, 'daily-digest', 'a.md'), '# Daily\n');
+    await mkdir(path.join(sourceRoot, 'recruit', 'interview-questions'), { recursive: true });
+    await writeFile(path.join(sourceRoot, 'recruit', 'interview-questions', 'foo.md'), '# Foo\n');
+
+    const { registerLogicalPage } = await import('../src/pages/page-store.js');
+    registerLogicalPage({ uri: 'top', title: 'Top', sourcePath: path.join(sourceRoot, 'top.md'), component: 'source' }, config);
+    registerLogicalPage({ uri: 'daily-digest/a', title: 'Daily', sourcePath: path.join(sourceRoot, 'daily-digest', 'a.md'), component: 'source' }, config);
+    registerLogicalPage({ uri: 'recruit/interview-questions/foo', title: 'Foo', sourcePath: path.join(sourceRoot, 'recruit', 'interview-questions', 'foo.md'), component: 'source' }, config);
 
     const pages = await scanPages(contentDir);
     const tree = buildPageTree(pages);
 
     assert.deepEqual(pages.map(page => page.slug).sort(), [
-      'daily-digest/a',
-      'recruit/interview-questions/foo',
-      'top',
+      'p/daily-digest/a',
+      'p/recruit/interview-questions/foo',
+      'p/top',
     ]);
-    assert.deepEqual(tree.topLevel.map(page => page.slug), ['top']);
+    assert.equal(pages.some(page => page.slug === 'bare'), false);
+    assert.deepEqual(tree.topLevel.map(page => page.slug), ['p/top']);
     assert.deepEqual(tree.folders.map(folder => folder.path), ['daily-digest', 'recruit/interview-questions']);
   } finally {
     await rm(contentDir, { recursive: true, force: true });
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(sourceRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Switch owner-only Pages navigation from filesystem scanning to the `logical_pages` registry
- Preserve logical path folder grouping while linking registered pages through `/p/<uri>`
- Cover registered-only navigation and bare-content exclusion in tests

## Validation
- `npm test -- test/page-tree.test.js`
- `npm test -- test/html-artifacts.test.js`
- `npm test`
- `npm run build:admin`
- `git diff --check`

Issue: 426d6e41-24ea-40a7-84be-b581ef6e7701
Task: c4026d2c-51e3-42f1-b443-f5356223d480