### PR TITLE
Fail closed when auth password is missing

### DIFF
--- a/src/security/auth.js
+++ b/src/security/auth.js
@@ -454,13 +454,24 @@ function loginPageHtml(baseUrl, error, next) {
  * /pages before proxying; direct localhost access uses root-relative URLs.
  */
 export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
-  if (authConfig.enabled && authConfig.password) {
+  migratePasswordIfNeeded(authConfig);
+
+  const authDisabled = authConfig.enabled === false;
+  const authPasswordConfigured = typeof authConfig.password === 'string' && authConfig.password.length > 0;
+  const authMisconfigured = !authDisabled && !authPasswordConfigured;
+
+  if (!authDisabled && authPasswordConfigured) {
     initSessionStore();
   }
-  migratePasswordIfNeeded(authConfig);
 
   const loginPath = '/login';
   const logoutPath = '/logout';
+
+  function rejectAuthMisconfigured(req, res) {
+    logger.error('auth misconfigured', { path: req.path, reason: 'missing_password' });
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(503).send('Authentication is not configured.');
+  }
 
   // Parse URL-encoded bodies for login form
   function parseLoginBody(req, res, next) {
@@ -480,6 +491,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
 
   // GET /login — show login page
   function loginGet(req, res) {
+    if (authMisconfigured) return rejectAuthMisconfigured(req, res);
     const browserBase = browserBaseFromRequest(req);
     if (validateSession(getSessionCookie(req))) {
       return res.redirect(browserRoot(browserBase));
@@ -492,6 +504,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
 
   // POST /login — authenticate
   function loginPost(req, res) {
+    if (authMisconfigured) return rejectAuthMisconfigured(req, res);
     const browserBase = browserBaseFromRequest(req);
     const ip = getClientIp(req);
 
@@ -527,6 +540,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
 
   // POST /logout — same-host CSRF protection
   function logoutPost(req, res) {
+    if (authMisconfigured) return rejectAuthMisconfigured(req, res);
     const expectedHost = req.headers.host;
     const origin = req.headers.origin;
     const referer = req.headers.referer;
@@ -563,13 +577,24 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
   // Auth middleware — protect all other routes
   app.use((req, res, next) => {
     const browserBase = browserBaseFromRequest(req);
-    if (!authConfig.enabled || !authConfig.password) return next();
+    if (authDisabled) return next();
 
     const shortShareEnabled = sharingConfig?.enabled !== false;
     if (req.path.startsWith('/_assets')
         || (shortShareEnabled && /^\/s\/[a-f0-9]{32}$/.test(req.path))
         || req.path === loginPath || req.path === logoutPath) {
       return next();
+    }
+
+    if ((req.method === 'GET' || req.method === 'HEAD')
+        && req.path.startsWith('/assets/')
+        && typeof req.query.exp === 'string'
+        && typeof req.query.sig === 'string') {
+      return next();
+    }
+
+    if (authMisconfigured) {
+      return rejectAuthMisconfigured(req, res);
     }
 
     // Share access session bypass for pages and raw HTML artifacts.
@@ -623,13 +648,6 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
         return next();
       }
       logger.info('api share token invalid', { path: req.path, ip: getClientIp(req) });
-    }
-
-    if ((req.method === 'GET' || req.method === 'HEAD')
-        && req.path.startsWith('/assets/')
-        && typeof req.query.exp === 'string'
-        && typeof req.query.sig === 'string') {
-      return next();
     }
 
     if (validateSession(getSessionCookie(req))) {

--- a/test/auth-routes.test.js
+++ b/test/auth-routes.test.js
@@ -15,12 +15,21 @@ test.after(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-function makeServer() {
+function makeServer(authConfig = {
+  enabled: true,
+  password: hashPassword('secret'),
+}) {
   const app = express();
-  setupAuth(app, {
-    enabled: true,
-    password: hashPassword('secret'),
-  });
+  setupAuth(app, authConfig);
+  app.get('/_assets/style.css', (_req, res) => res.type('text/css').send('body{}'));
+  app.get('/s/:tokenId', (_req, res) => res.send('share'));
+  app.get('/assets/:uri(*)', (_req, res) => res.send('signed asset'));
+  app.get('/api/raw/:slug(*)', (_req, res) => res.send('raw'));
+  app.get('/api/state/:artifact(*)', (_req, res) => res.json({ ok: true }));
+  app.get('/api/attachments/:artifact/:key', (_req, res) => res.json({ attachments: [] }));
+  app.get('/api/pages', (_req, res) => res.json({ pages: [] }));
+  app.get('/api/shares/:slug(*)', (_req, res) => res.json({ shares: [] }));
+  app.post('/api/share', (_req, res) => res.json({ ok: true }));
   app.get('/', (_req, res) => res.send('root'));
   app.get('/:slug(*)', (req, res) => res.send(`page:${req.params.slug || req.params[0]}`));
 
@@ -32,6 +41,56 @@ function makeServer() {
     });
   });
 }
+
+test('auth enabled without password fails closed while allowing only public assets and explicit share paths', async () => {
+  const { server, origin } = await makeServer({ enabled: true, password: null });
+  try {
+    const allowed = [
+      '/_assets/style.css',
+      '/s/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '/assets/docs/page?path=diagram.png&exp=9999999999999&sig=test',
+    ];
+
+    for (const requestPath of allowed) {
+      const response = await fetch(`${origin}${requestPath}`, { redirect: 'manual' });
+      assert.equal(response.status, 200, `${requestPath} should be allowed`);
+    }
+
+    const protectedGets = [
+      '/',
+      '/docs/page',
+      '/image.jpg',
+      '/login',
+      '/api/raw/docs/page',
+      '/api/state/docs/page',
+      '/api/attachments/docs/page/key',
+      '/api/pages',
+      '/api/shares/docs/page',
+    ];
+
+    for (const requestPath of protectedGets) {
+      const response = await fetch(`${origin}${requestPath}`, { redirect: 'manual' });
+      assert.equal(response.status, 503, `${requestPath} should fail closed`);
+      assert.equal(await response.text(), 'Authentication is not configured.');
+    }
+
+    const shareCreate = await fetch(`${origin}/api/share`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { Origin: origin },
+    });
+    assert.equal(shareCreate.status, 503);
+
+    const logout = await fetch(`${origin}/logout`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { Origin: origin },
+    });
+    assert.equal(logout.status, 503);
+  } finally {
+    server.close();
+  }
+});
 
 test('login route uses root-relative paths for direct local access', async () => {
   const { server, origin } = await makeServer();

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -25,7 +25,7 @@ function cookieHeader(setCookie) {
     .join('; ');
 }
 
-function makeServer({ auth = false, sharingEnabled = true, shareViewer = false } = {}) {
+function makeServer({ auth = false, authConfig = null, sharingEnabled = true, shareViewer = false } = {}) {
   const contentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-pages-share-content-'));
   fs.mkdirSync(path.join(contentDir, 'docs'), { recursive: true });
   fs.writeFileSync(path.join(contentDir, 'docs', 'page.html'), '<!doctype html><head><title>Shared page</title></head><h1>Shared page</h1>');
@@ -36,8 +36,8 @@ function makeServer({ auth = false, sharingEnabled = true, shareViewer = false }
     toc: { minHeadings: 3 },
     theme: { codeTheme: 'github-dark' },
   };
-  if (auth) {
-    setupAuth(app, {
+  if (auth || authConfig) {
+    setupAuth(app, authConfig || {
       enabled: true,
       password: hashPassword('secret'),
     }, { enabled: sharingEnabled });
@@ -274,6 +274,22 @@ test('short share URL sets access cookie and renders clean page in place', async
     assert.match(setCookie, /__Host-share_access=/);
     assert.doesNotMatch(setCookie, /__Host-share_scope=/);
     assert.match(await redirect.text(), /<base href="\/docs\/page">/);
+  } finally {
+    server.close();
+  }
+});
+
+test('short share URL remains accessible when auth is enabled without password', async () => {
+  const share = createShare('docs/page', '24h', { allowPermanent: false });
+  const { server, origin } = await makeServer({
+    authConfig: { enabled: true, password: null },
+  });
+  try {
+    const response = await fetch(`${origin}/s/${share.tokenId}`);
+    assert.equal(response.status, 200);
+    const body = await response.text();
+    assert.match(body, /Shared page/);
+    assert.doesNotMatch(body, /Authentication is not configured/);
   } finally {
     server.close();
   }


### PR DESCRIPTION
## Summary
- Treat auth enabled without a configured password as a fail-closed misconfiguration instead of bypassing auth
- Keep explicit public/share surfaces available: static assets, short share URLs, and signed share assets
- Add focused coverage for protected routes under missing-password auth config and short-share access

## Tests
- npm test -- test/auth-routes.test.js test/share-api.test.js test/asset-route.test.js
- git diff --check

Full suite was also run before this commit and passed 100/100.