### PR TITLE
Fix pages registry bypass

### DIFF
--- a/src/routes/raw-api.js
+++ b/src/routes/raw-api.js
@@ -3,6 +3,7 @@
 
 import { readFile } from 'node:fs/promises';
 import { resolveSafePath } from '../security/pathGuard.js';
+import { getLogicalPage } from '../pages/page-store.js';
 import { normalizeSlug } from '../utils/slug.js';
 import { logger } from '../utils/logger.js';
 
@@ -24,7 +25,14 @@ export function setupRawApi(app, config) {
 
     try {
       slug = normalizeSlug(rawSlug);
-      filePath = resolveSafePath(slug, config.contentDir);
+      resolveSafePath(slug, config.contentDir);
+      const pageUri = slug.startsWith('p/') ? slug.slice(2) : slug;
+      const logicalPage = getLogicalPage(pageUri);
+      if (!logicalPage || logicalPage.sourceExt !== '.md') {
+        logger.info('raw markdown not found', { path: slug });
+        return res.status(404).json({ error: 'Page not found' });
+      }
+      filePath = logicalPage.sourcePath;
     } catch (err) {
       const status = err.statusCode || 400;
       logger.warn('raw markdown path rejected', { path: rawSlug, status, err: err.message });

--- a/src/routes/share-api.js
+++ b/src/routes/share-api.js
@@ -17,6 +17,8 @@ import {
 import { logger } from '../utils/logger.js';
 import { browserBaseFromRequest, browserPath } from '../lib/browser-base.js';
 import { renderSharePage } from './pages.js';
+import { getLogicalPage } from '../pages/page-store.js';
+import { normalizeSlug } from '../utils/slug.js';
 
 /**
  * CSRF validation via Origin/Referer headers (same approach as logout).
@@ -99,6 +101,15 @@ function appendSetCookie(res, cookie) {
   }
 }
 
+function registeredShareSlug(rawSlug) {
+  const normalized = normalizeSlug(rawSlug);
+  const pageUri = normalized.startsWith('p/') ? normalized.slice(2) : normalized;
+  if (!pageUri || !getLogicalPage(pageUri)) {
+    throw Object.assign(new Error('Page not found'), { statusCode: 404 });
+  }
+  return `p/${pageUri}`;
+}
+
 /**
  * Register share API routes on the Express app.
  * Must be called AFTER auth middleware so that only authenticated users reach these.
@@ -150,7 +161,8 @@ export function setupShareApi(app, sharingConfig, config = {}) {
         return res.status(400).json({ error: 'Missing duration' });
       }
 
-      const result = createShare(slug, duration, sharingConfig, { canWriteAttachments });
+      const shareSlug = registeredShareSlug(slug);
+      const result = createShare(shareSlug, duration, sharingConfig, { canWriteAttachments });
 
       const share = formatShareResponse(req, result);
 

--- a/src/security/pathGuard.js
+++ b/src/security/pathGuard.js
@@ -1,7 +1,6 @@
 // Path traversal protection (P0-1)
 
 import { resolve, relative, extname } from 'node:path';
-import { access } from 'node:fs/promises';
 import { getMimeType, isAssetExtension } from '../utils/mime.js';
 import { getLogicalPage } from '../pages/page-store.js';
 
@@ -65,19 +64,9 @@ function resolveCandidate(slug, contentRoot, extension) {
   return candidate;
 }
 
-async function exists(filePath) {
-  try {
-    await access(filePath);
-    return true;
-  } catch (err) {
-    if (err.code === 'ENOENT') return false;
-    throw err;
-  }
-}
-
 /**
  * Resolve a slug to the page representation that should be served to humans.
- * HTML artifacts take priority over markdown, but only these two extensions are considered.
+ * Only registered logical pages are served; unregistered contentDir files 404.
  */
 export async function resolvePageDescriptor(slug, contentRoot) {
   validateSlug(slug);
@@ -90,29 +79,6 @@ export async function resolvePageDescriptor(slug, contentRoot) {
       logical: true,
       title: logicalPage.title,
       accessMode: logicalPage.accessMode,
-    };
-  }
-
-  const htmlPath = resolveCandidate(slug, contentRoot, '.html');
-  const markdownPath = resolveCandidate(slug, contentRoot, '.md');
-
-  if (await exists(htmlPath)) {
-    const descriptor = {
-      type: 'html',
-      filePath: htmlPath,
-      slug,
-    };
-    if (await exists(markdownPath)) {
-      descriptor.companionPath = markdownPath;
-    }
-    return descriptor;
-  }
-
-  if (await exists(markdownPath)) {
-    return {
-      type: 'markdown',
-      filePath: markdownPath,
-      slug,
     };
   }
 

--- a/test/asset-route.test.js
+++ b/test/asset-route.test.js
@@ -36,7 +36,17 @@ function baseConfig(contentDir, auth = { enabled: false, password: null }) {
     toc: { minHeadings: 3 },
     theme: { codeTheme: 'github-dark' },
     auth,
+    externalFiles: { allowedSources: { content: contentDir } },
   };
+}
+
+function registerPage(config, uri, sourcePath, title = uri) {
+  return registerLogicalPage({
+    uri,
+    title,
+    sourcePath,
+    component: 'content',
+  }, config);
 }
 
 async function makeContentDir() {
@@ -317,15 +327,18 @@ test('authenticated /p view resolves out-of-directory assets within allowed root
 test('share page access renders in place and signs referenced assets', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'renovation-checklist.html'), '<!doctype html><img src="kitchen-ref.jpg">');
+    const config = baseConfig(contentDir, { enabled: true, password: hashPassword('secret') });
+    const pagePath = path.join(contentDir, 'renovation-checklist.html');
+    await writeFile(pagePath, '<!doctype html><img src="kitchen-ref.jpg">');
     await writeFile(path.join(contentDir, 'kitchen-ref.jpg'), 'kitchen image');
     await writeFile(path.join(contentDir, 'direct-token.jpg'), 'direct token image');
     await mkdir(path.join(contentDir, 'docs'));
     await writeFile(path.join(contentDir, 'docs', 'nested.jpg'), 'nested image');
+    registerPage(config, 'renovation-checklist', pagePath, 'Renovation checklist');
     const share = createShare('renovation-checklist', '24h', { allowPermanent: false });
     const assetToken = createShare('direct-token.jpg', '24h', { allowPermanent: false }).token;
 
-    await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
+    await withServer(config, async ({ origin }) => {
       const redirect = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
       assert.equal(redirect.status, 200);
       assert.equal(redirect.headers.get('location'), null);
@@ -366,18 +379,21 @@ test('share page access renders in place and signs referenced assets', async () 
 test('signed share assets allow page assets while isolating unsigned siblings', async () => {
   const contentDir = await makeContentDir();
   try {
+    const config = baseConfig(contentDir, { enabled: true, password: hashPassword('secret') });
     await mkdir(path.join(contentDir, 'docs'));
     await mkdir(path.join(contentDir, 'other'));
     await mkdir(path.join(contentDir, 'shared'));
-    await writeFile(path.join(contentDir, 'docs', 'guide.html'), '<!doctype html><img src="diagram.png"><img src="../shared/logo.png">');
+    const pagePath = path.join(contentDir, 'docs', 'guide.html');
+    await writeFile(pagePath, '<!doctype html><img src="diagram.png"><img src="../shared/logo.png">');
     await writeFile(path.join(contentDir, 'docs', 'diagram.png'), 'diagram');
     await writeFile(path.join(contentDir, 'shared', 'logo.png'), 'logo');
     await writeFile(path.join(contentDir, 'shared', 'secret.png'), 'secret');
     await writeFile(path.join(contentDir, 'root.png'), 'root');
     await writeFile(path.join(contentDir, 'other', 'secret.png'), 'secret');
+    registerPage(config, 'docs/guide', pagePath, 'Guide');
     const token = createShare('docs/guide', '24h', { allowPermanent: false }).token;
 
-    await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
+    await withServer(config, async ({ origin }) => {
       const page = await fetch(`${origin}/docs/guide?token=${encodeURIComponent(token)}`);
       assert.equal(page.status, 200);
       const body = await page.text();
@@ -438,11 +454,14 @@ test('expired and tampered share-scope cookies fall through to auth wall', async
 test('revoked share invalidates existing signed asset URLs', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'shared.html'), '<!doctype html><img src="asset.jpg">');
+    const config = baseConfig(contentDir, { enabled: true, password: hashPassword('secret') });
+    const pagePath = path.join(contentDir, 'shared.html');
+    await writeFile(pagePath, '<!doctype html><img src="asset.jpg">');
     await writeFile(path.join(contentDir, 'asset.jpg'), 'asset');
+    registerPage(config, 'shared', pagePath, 'Shared');
     const share = createShare('shared', '24h', { allowPermanent: false });
 
-    await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
+    await withServer(config, async ({ origin }) => {
       const page = await fetch(`${origin}/shared?token=${encodeURIComponent(share.token)}`);
       assert.equal(page.status, 200);
       const signedPath = signedAssetPath(await page.text(), 'asset.jpg');
@@ -490,10 +509,13 @@ test('asset route rejects traversal, null byte, and double-encoded traversal', a
 test('login clears legacy share-scope cookie without overwriting session cookie', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'shared.html'), '<!doctype html><h1>Shared</h1>');
+    const config = baseConfig(contentDir, { enabled: true, password: hashPassword('secret') });
+    const pagePath = path.join(contentDir, 'shared.html');
+    await writeFile(pagePath, '<!doctype html><h1>Shared</h1>');
+    registerPage(config, 'shared', pagePath, 'Shared');
     const token = createShare('shared', '24h', { allowPermanent: false }).token;
 
-    await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
+    await withServer(config, async ({ origin }) => {
       await fetch(`${origin}/shared?token=${encodeURIComponent(token)}`);
       const legacy = createShareScopeCookie('shared', createShare('shared', '24h', { allowPermanent: false }).tokenId, Date.now() + 3600_000).value;
       const shareCookie = `${SHARE_SCOPE_COOKIE_NAME}=${legacy}`;
@@ -510,10 +532,15 @@ test('login clears legacy share-scope cookie without overwriting session cookie'
 test('markdown, html artifact, extension redirects, and state API still work with asset route registered', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'foo.md'), '# Foo\n');
-    await writeFile(path.join(contentDir, 'artifact.html'), '<!doctype html><head><title>A</title></head><h1>A</h1>');
+    const config = baseConfig(contentDir);
+    const fooPath = path.join(contentDir, 'foo.md');
+    const artifactPath = path.join(contentDir, 'artifact.html');
+    await writeFile(fooPath, '# Foo\n');
+    await writeFile(artifactPath, '<!doctype html><head><title>A</title></head><h1>A</h1>');
+    registerPage(config, 'foo', fooPath, 'Foo');
+    registerPage(config, 'artifact', artifactPath, 'Artifact');
 
-    await withServer(baseConfig(contentDir), async ({ origin }) => {
+    await withServer(config, async ({ origin }) => {
       let res = await fetch(`${origin}/foo`);
       assert.equal(res.status, 200);
       assert.match(await res.text(), /Foo/);

--- a/test/attachment-api.test.js
+++ b/test/attachment-api.test.js
@@ -16,6 +16,7 @@ const { setupAuth, hashPassword } = await import('../src/security/auth.js');
 const { createShare, revokeShare } = await import('../src/sharing/share-manager.js');
 const { getPagesDb } = await import('../src/db/pages-db.js');
 const { getAttachment } = await import('../src/attachments/attachment-store.js');
+const { registerLogicalPage } = await import('../src/pages/page-store.js');
 
 const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
 const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
@@ -29,6 +30,8 @@ async function makeContentDir() {
   const contentDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-attachment-content-'));
   await writeFile(path.join(contentDir, 'renovation-checklist.html'), '<!doctype html><h1>Checklist</h1>');
   await writeFile(path.join(contentDir, 'notes.md'), '# Notes\n');
+  registerContentPage(contentDir, 'renovation-checklist');
+  registerContentPage(contentDir, 'notes');
   return contentDir;
 }
 
@@ -42,7 +45,18 @@ function baseConfig(contentDir, auth = authConfig(), extra = {}) {
     auth,
     sharing: { enabled: true, allowPermanent: false },
     attachments: { maxFileSizeBytes: 128, ...(extra.attachments || {}) },
+    externalFiles: { allowedSources: { content: contentDir } },
   };
+}
+
+function registerContentPage(contentDir, uri, title = uri) {
+  const ext = uri === 'notes' ? '.md' : '.html';
+  return registerLogicalPage({
+    uri,
+    title,
+    sourcePath: path.join(contentDir, `${uri}${ext}`),
+    component: 'content',
+  }, baseConfig(contentDir));
 }
 
 async function withServer(config, fn, options = {}) {
@@ -497,6 +511,7 @@ test('failed uploads clean temporary and final files without durable metadata', 
   const contentDir = await makeContentDir();
   try {
     await writeFile(path.join(contentDir, 'cleanup-artifact.html'), '<!doctype html><h1>Cleanup</h1>');
+    registerContentPage(contentDir, 'cleanup-artifact');
     await withServer(baseConfig(contentDir), async ({ origin }) => {
       const cookie = await login(origin);
       let res = await upload(origin, 'cleanup-artifact', 'cleanup-rejected', cookie, Buffer.from('bad'), 'image/jpeg', 'bad.jpg');
@@ -538,6 +553,7 @@ test('delete succeeds when stored file is missing and returns 404 when metadata 
   const contentDir = await makeContentDir();
   try {
     await writeFile(path.join(contentDir, 'delete-artifact.html'), '<!doctype html><h1>Delete</h1>');
+    registerContentPage(contentDir, 'delete-artifact');
     await withServer(baseConfig(contentDir), async ({ origin }) => {
       const cookie = await login(origin);
       let res = await upload(origin, 'delete-artifact', 'delete-missing-file', cookie);

--- a/test/external-files.test.js
+++ b/test/external-files.test.js
@@ -299,13 +299,32 @@ test('page service renders root-internal and forwarded-prefix browser bases sepa
   const fixture = makeFixture();
   const nestedDir = path.join(fixture.contentDir, 'docs');
   fs.mkdirSync(nestedDir, { recursive: true });
-  fs.writeFileSync(path.join(nestedDir, 'nested.md'), '# Nested Page\n');
+  const source = path.join(nestedDir, 'nested.md');
+  fs.writeFileSync(source, '# Nested Page\n');
+  runPagesCli(fixture, [
+    'allow-root',
+    'add',
+    fixture.contentDir,
+    '--name',
+    'content',
+    '--json',
+  ]);
+  runPagesCli(fixture, [
+    'register',
+    '--component',
+    'content',
+    '--uri',
+    'docs/nested',
+    '--source',
+    source,
+    '--json',
+  ]);
 
-  const direct = await getPage('docs/nested', configFor(fixture), '');
+  const direct = await getPage('p/docs/nested', configFor(fixture), '');
   assert.match(direct.html, /href="\/_assets\/style\.css/);
   assert.match(direct.html, /data-base-url=""/);
 
-  const proxied = await getPage('docs/nested', configFor(fixture), '/pages');
+  const proxied = await getPage('p/docs/nested', configFor(fixture), '/pages');
   assert.match(proxied.html, /href="\/pages\/_assets\/style\.css/);
   assert.match(proxied.html, /data-base-url="\/pages"/);
 });

--- a/test/html-artifacts.test.js
+++ b/test/html-artifacts.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
@@ -12,6 +12,7 @@ const express = (await import('express')).default;
 const { initCache } = await import('../src/cache/pageCache.js');
 const { getPage } = await import('../src/services/pageService.js');
 const { scanPages } = await import('../src/pages/navigation.js');
+const { registerLogicalPage } = await import('../src/pages/page-store.js');
 const { pageRoute } = await import('../src/routes/pages.js');
 const { setupRawApi } = await import('../src/routes/raw-api.js');
 const { setupShareApi } = await import('../src/routes/share-api.js');
@@ -36,6 +37,7 @@ function baseConfig(contentDir) {
     toc: { minHeadings: 3 },
     theme: { codeTheme: 'github-dark' },
     auth: { enabled: false, password: null },
+    externalFiles: { allowedSources: { content: contentDir } },
   };
 }
 
@@ -48,6 +50,15 @@ function cookieHeader(setCookie) {
 
 async function makeContentDir() {
   return mkdtemp(path.join(os.tmpdir(), 'zylos-pages-html-content-'));
+}
+
+function registerPage(config, uri, sourcePath, title = uri) {
+  return registerLogicalPage({
+    uri,
+    title,
+    sourcePath,
+    component: 'content',
+  }, config);
 }
 
 async function withServer(config, fn) {
@@ -80,28 +91,31 @@ test('normalizeSlug strips html and markdown extensions', () => {
   assert.equal(normalizeSlug('/foo'), 'foo');
 });
 
-test('resolvePageDescriptor selects html priority and preserves markdown resolver ownership', async () => {
+test('resolvePageDescriptor serves registered logical pages only', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'html-only.html'), '<title>HTML</title>');
-    await writeFile(path.join(contentDir, 'markdown-only.md'), '# Markdown\n');
-    await writeFile(path.join(contentDir, 'both.html'), '<title>Both</title>');
-    await writeFile(path.join(contentDir, 'both.md'), '# Both Markdown\n');
+    const config = baseConfig(contentDir);
+    const htmlPath = path.join(contentDir, 'html-only.html');
+    const markdownPath = path.join(contentDir, 'markdown-only.md');
+    const barePath = path.join(contentDir, 'bare.md');
+    await writeFile(htmlPath, '<title>HTML</title>');
+    await writeFile(markdownPath, '# Markdown\n');
+    await writeFile(barePath, '# Bare\n');
+    registerPage(config, 'html-only', htmlPath, 'HTML');
+    registerPage(config, 'markdown-only', markdownPath, 'Markdown');
 
     const htmlOnly = await resolvePageDescriptor('html-only', contentDir);
     assert.equal(htmlOnly.type, 'html');
-    assert.equal(htmlOnly.filePath, path.join(contentDir, 'html-only.html'));
+    assert.equal(htmlOnly.filePath, await realpath(htmlPath));
+    assert.equal(htmlOnly.logical, true);
 
     const markdownOnly = await resolvePageDescriptor('markdown-only', contentDir);
     assert.equal(markdownOnly.type, 'markdown');
-    assert.equal(markdownOnly.filePath, path.join(contentDir, 'markdown-only.md'));
+    assert.equal(markdownOnly.filePath, await realpath(markdownPath));
+    assert.equal(markdownOnly.logical, true);
+    assert.equal(resolveSafePath('markdown-only', contentDir), markdownPath);
 
-    const both = await resolvePageDescriptor('both', contentDir);
-    assert.equal(both.type, 'html');
-    assert.equal(both.filePath, path.join(contentDir, 'both.html'));
-    assert.equal(both.companionPath, path.join(contentDir, 'both.md'));
-    assert.equal(resolveSafePath('both', contentDir), path.join(contentDir, 'both.md'));
-
+    await assert.rejects(() => resolvePageDescriptor('bare', contentDir), { code: 'ENOENT' });
     await assert.rejects(() => resolvePageDescriptor('missing', contentDir), { code: 'ENOENT' });
   } finally {
     await rm(contentDir, { recursive: true, force: true });
@@ -122,16 +136,27 @@ test('resolvePageDescriptor rejects html traversal and null byte slugs', async (
 test('page route serves markdown with default CSP and html artifacts wrapped with iframe', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'foo.md'), '# Foo Markdown\n');
-    await writeFile(path.join(contentDir, 'artifact.html'), '<!doctype html><title>Artifact</title><script>window.ok=true</script><h1>Artifact</h1>');
-    await writeFile(path.join(contentDir, 'both.md'), '# Both Markdown\n');
-    await writeFile(path.join(contentDir, 'both.html'), '<!doctype html><title>Both HTML</title><script>window.ok=true</script><h1>Both HTML</h1>');
+    const config = baseConfig(contentDir);
+    const fooPath = path.join(contentDir, 'foo.md');
+    const artifactPath = path.join(contentDir, 'artifact.html');
+    const bothPath = path.join(contentDir, 'both.html');
+    const barePath = path.join(contentDir, 'bare.md');
+    await writeFile(fooPath, '# Foo Markdown\n');
+    await writeFile(artifactPath, '<!doctype html><title>Artifact</title><script>window.ok=true</script><h1>Artifact</h1>');
+    await writeFile(bothPath, '<!doctype html><title>Both HTML</title><script>window.ok=true</script><h1>Both HTML</h1>');
+    await writeFile(barePath, '# Bare Markdown\n');
+    registerPage(config, 'foo', fooPath, 'Foo');
+    registerPage(config, 'artifact', artifactPath, 'Artifact');
+    registerPage(config, 'both', bothPath, 'Both HTML');
 
-    await withServer(baseConfig(contentDir), async ({ origin }) => {
+    await withServer(config, async ({ origin }) => {
       const markdown = await fetch(`${origin}/foo`);
       assert.equal(markdown.status, 200);
       assert.equal(markdown.headers.get('content-security-policy'), DEFAULT_CSP);
       assert.match(await markdown.text(), /Foo Markdown/);
+
+      const unregistered = await fetch(`${origin}/bare`);
+      assert.equal(unregistered.status, 404);
 
       // Default HTML artifact response: wrapper template with iframe
       const html = await fetch(`${origin}/artifact`);
@@ -180,13 +205,18 @@ test('page route serves markdown with default CSP and html artifacts wrapped wit
 test('shared html artifacts render directly while shared markdown keeps page header', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'shared.html'), '<!doctype html><title>Shared</title><h1>Shared HTML</h1>');
-    await writeFile(path.join(contentDir, 'shared-markdown.md'), '# Shared Markdown\n');
+    const config = baseConfig(contentDir);
+    const sharedPath = path.join(contentDir, 'shared.html');
+    const sharedMarkdownPath = path.join(contentDir, 'shared-markdown.md');
+    await writeFile(sharedPath, '<!doctype html><title>Shared</title><h1>Shared HTML</h1>');
+    await writeFile(sharedMarkdownPath, '# Shared Markdown\n');
+    registerPage(config, 'shared', sharedPath, 'Shared');
+    registerPage(config, 'shared-markdown', sharedMarkdownPath, 'Shared Markdown');
     const htmlToken = createShare('shared', '24h', { allowPermanent: false }).token;
     const markdownToken = createShare('shared-markdown', '24h', { allowPermanent: false }).token;
 
     await withServer({
-      ...baseConfig(contentDir),
+      ...config,
       auth: { enabled: true, password: hashPassword('secret') },
     }, async ({ origin }) => {
       const redirect = await fetch(`${origin}/shared.html?token=${encodeURIComponent(htmlToken)}`, { redirect: 'manual' });
@@ -222,10 +252,13 @@ test('shared html artifacts render directly while shared markdown keeps page hea
 test('html pages require auth when no valid share token is present', async () => {
   const contentDir = await makeContentDir();
   try {
-    await writeFile(path.join(contentDir, 'private.html'), '<!doctype html><title>Private</title>');
+    const config = baseConfig(contentDir);
+    const privatePath = path.join(contentDir, 'private.html');
+    await writeFile(privatePath, '<!doctype html><title>Private</title>');
+    registerPage(config, 'private', privatePath, 'Private');
 
     await withServer({
-      ...baseConfig(contentDir),
+      ...config,
       auth: { enabled: true, password: hashPassword('secret') },
     }, async ({ origin }) => {
       const res = await fetch(`${origin}/private`, { redirect: 'manual' });
@@ -240,12 +273,15 @@ test('html pages require auth when no valid share token is present', async () =>
 test('raw API returns markdown when both html and markdown exist, and share viewers remain blocked', async () => {
   const contentDir = await makeContentDir();
   try {
+    const config = baseConfig(contentDir);
+    const sourcePath = path.join(contentDir, 'source.md');
     await writeFile(path.join(contentDir, 'source.html'), '<!doctype html><title>HTML</title>');
-    await writeFile(path.join(contentDir, 'source.md'), '# Markdown Source\n');
+    await writeFile(sourcePath, '# Markdown Source\n');
+    registerPage(config, 'source', sourcePath, 'Source');
     const token = createShare('source', '24h', { allowPermanent: false }).token;
 
     await withServer({
-      ...baseConfig(contentDir),
+      ...config,
       auth: { enabled: true, password: hashPassword('secret') },
     }, async ({ origin }) => {
       const rawAsShare = await fetch(`${origin}/api/raw/source?token=${encodeURIComponent(token)}`, { redirect: 'manual' });
@@ -269,7 +305,7 @@ test('raw API returns markdown when both html and markdown exist, and share view
       res.locals.viewerType = 'share';
       next();
     });
-    setupRawApi(app, baseConfig(contentDir));
+    setupRawApi(app, config);
     const server = await new Promise((resolve) => {
       const s = http.createServer(app);
       s.listen(0, '127.0.0.1', () => resolve(s));
@@ -311,9 +347,10 @@ test('scanPages lists registered logical pages instead of bare content files', a
     });
 
     const pages = await scanPages(contentDir);
-    assert.deepEqual(pages.map(page => [page.slug, page.title, page.type]), [
-      ['p/docs/registered', 'Registered HTML', 'html'],
-    ]);
+    assert.ok(pages.some(page => page.slug === 'p/docs/registered'
+      && page.title === 'Registered HTML'
+      && page.type === 'html'));
+    assert.equal(pages.some(page => page.slug === 'p/bare'), false);
   } finally {
     await rm(contentDir, { recursive: true, force: true });
   }
@@ -324,29 +361,34 @@ test('page cache switches between markdown and html descriptors and updates html
   try {
     initCache({ maxEntries: 10, ttlSeconds: 60 });
     const config = baseConfig(contentDir);
-    await writeFile(path.join(contentDir, 'switch.md'), '# Markdown First\n');
+    const markdownPath = path.join(contentDir, 'switch.md');
+    const htmlPath = path.join(contentDir, 'switch.html');
+    await writeFile(markdownPath, '# Markdown First\n');
+    registerPage(config, 'switch', markdownPath, 'Switch Markdown');
 
     const markdown = await getPage('switch', config);
     assert.equal(markdown.type, 'markdown');
     assert.match(markdown.html, /Markdown First/);
 
-    await writeFile(path.join(contentDir, 'switch.html'), '<!doctype html><title>HTML First</title><h1>HTML First</h1>');
+    await writeFile(htmlPath, '<!doctype html><title>HTML First</title><h1>HTML First</h1>');
+    registerPage(config, 'switch', htmlPath, 'Switch HTML');
     const html = await getPage('switch', config);
     assert.equal(html.type, 'html');
     assert.match(html.html, /HTML First/);
 
-    await unlink(path.join(contentDir, 'switch.html'));
+    registerPage(config, 'switch', markdownPath, 'Switch Markdown');
     const fallback = await getPage('switch', config);
     assert.equal(fallback.type, 'markdown');
     assert.match(fallback.html, /Markdown First/);
 
-    await writeFile(path.join(contentDir, 'switch.html'), '<!doctype html><title>HTML Two</title><h1>HTML Two</h1>');
+    await writeFile(htmlPath, '<!doctype html><title>HTML Two</title><h1>HTML Two</h1>');
+    registerPage(config, 'switch', htmlPath, 'Switch HTML');
     const htmlTwo = await getPage('switch', config);
     assert.match(htmlTwo.html, /HTML Two/);
     const firstEtag = htmlTwo.etag;
 
     await new Promise(resolve => setTimeout(resolve, 20));
-    await writeFile(path.join(contentDir, 'switch.html'), '<!doctype html><title>HTML Three</title><h1>HTML Three</h1>');
+    await writeFile(htmlPath, '<!doctype html><title>HTML Three</title><h1>HTML Three</h1>');
     const htmlThree = await getPage('switch', config);
     assert.match(htmlThree.html, /HTML Three/);
     assert.notEqual(htmlThree.etag, firstEtag);

--- a/test/raw-api.test.js
+++ b/test/raw-api.test.js
@@ -4,17 +4,30 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import express from 'express';
-import { setupRawApi } from '../src/routes/raw-api.js';
+
+const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-raw-data-'));
+process.env.PAGES_DATA_DIR = tmpDir;
+
+const { setupRawApi } = await import('../src/routes/raw-api.js');
+const { registerLogicalPage } = await import('../src/pages/page-store.js');
+
+test.after(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
 
 async function withServer(viewerType, fn) {
   const contentDir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-raw-'));
   const app = express();
+  const config = {
+    contentDir,
+    externalFiles: { allowedSources: { content: contentDir } },
+  };
 
   app.use((req, res, next) => {
     if (viewerType) res.locals.viewerType = viewerType;
     next();
   });
-  setupRawApi(app, { contentDir });
+  setupRawApi(app, config);
 
   const server = await new Promise((resolve) => {
     const s = app.listen(0, '127.0.0.1', () => resolve(s));
@@ -22,7 +35,7 @@ async function withServer(viewerType, fn) {
   const baseUrl = `http://127.0.0.1:${server.address().port}`;
 
   try {
-    await fn({ baseUrl, contentDir });
+    await fn({ baseUrl, contentDir, config });
   } finally {
     await new Promise((resolve, reject) => {
       server.close((err) => err ? reject(err) : resolve());
@@ -32,9 +45,11 @@ async function withServer(viewerType, fn) {
 }
 
 test('raw API returns the original Markdown text', async () => {
-  await withServer(null, async ({ baseUrl, contentDir }) => {
+  await withServer(null, async ({ baseUrl, contentDir, config }) => {
     const markdown = '---\ntitle: Raw Source\n---\n\n# Raw Source\n\nOriginal **Markdown**.\n';
-    await writeFile(path.join(contentDir, 'raw-source.md'), markdown);
+    const sourcePath = path.join(contentDir, 'raw-source.md');
+    await writeFile(sourcePath, markdown);
+    registerLogicalPage({ uri: 'raw-source', title: 'Raw Source', sourcePath, component: 'content' }, config);
 
     const res = await fetch(`${baseUrl}/api/raw/raw-source`);
     assert.equal(res.status, 200);
@@ -45,13 +60,27 @@ test('raw API returns the original Markdown text', async () => {
 });
 
 test('raw API supports nested Markdown slugs', async () => {
-  await withServer(null, async ({ baseUrl, contentDir }) => {
+  await withServer(null, async ({ baseUrl, contentDir, config }) => {
     await mkdir(path.join(contentDir, 'docs'), { recursive: true });
-    await writeFile(path.join(contentDir, 'docs', 'guide.md'), '# Guide\n');
+    const sourcePath = path.join(contentDir, 'docs', 'guide.md');
+    await writeFile(sourcePath, '# Guide\n');
+    registerLogicalPage({ uri: 'docs/guide', title: 'Guide', sourcePath, component: 'content' }, config);
 
     const res = await fetch(`${baseUrl}/api/raw/${encodeURIComponent('docs/guide')}`);
     assert.equal(res.status, 200);
     assert.equal(await res.text(), '# Guide\n');
+  });
+});
+
+test('raw API supports canonical p-prefixed logical page slugs', async () => {
+  await withServer(null, async ({ baseUrl, contentDir, config }) => {
+    const sourcePath = path.join(contentDir, 'registered.md');
+    await writeFile(sourcePath, '# Registered\n');
+    registerLogicalPage({ uri: 'docs/registered', title: 'Registered', sourcePath, component: 'content' }, config);
+
+    const res = await fetch(`${baseUrl}/api/raw/${encodeURIComponent('p/docs/registered')}`);
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '# Registered\n');
   });
 });
 
@@ -72,8 +101,10 @@ test('raw API rejects traversal slugs', async () => {
 });
 
 test('raw API is unavailable to share viewers', async () => {
-  await withServer('share', async ({ baseUrl, contentDir }) => {
-    await writeFile(path.join(contentDir, 'private.md'), '# Private\n');
+  await withServer('share', async ({ baseUrl, contentDir, config }) => {
+    const sourcePath = path.join(contentDir, 'private.md');
+    await writeFile(sourcePath, '# Private\n');
+    registerLogicalPage({ uri: 'private', title: 'Private', sourcePath, component: 'content' }, config);
 
     const res = await fetch(`${baseUrl}/api/raw/private`);
     assert.equal(res.status, 403);

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -13,6 +13,7 @@ const { setupShareApi } = await import('../src/routes/share-api.js');
 const { setupAuth, hashPassword } = await import('../src/security/auth.js');
 const { createShare, revokeShare } = await import('../src/sharing/share-manager.js');
 const { getPagesDb } = await import('../src/db/pages-db.js');
+const { registerLogicalPage } = await import('../src/pages/page-store.js');
 
 test.after(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -32,10 +33,17 @@ function makeServer({ auth = false, authConfig = null, sharingEnabled = true, sh
   const app = express();
   const config = {
     contentDir,
+    externalFiles: { allowedSources: { content: contentDir } },
     security: { allowRawHtml: false, maxFileSizeBytes: 1024 * 1024, renderTimeoutMs: 5000 },
     toc: { minHeadings: 3 },
     theme: { codeTheme: 'github-dark' },
   };
+  registerLogicalPage({
+    uri: 'docs/page',
+    title: 'Shared page',
+    sourcePath: path.join(contentDir, 'docs', 'page.html'),
+    component: 'content',
+  }, config);
   if (auth || authConfig) {
     setupAuth(app, authConfig || {
       enabled: true,
@@ -51,7 +59,7 @@ function makeServer({ auth = false, authConfig = null, sharingEnabled = true, sh
   if (sharingEnabled) {
     setupShareApi(app, { enabled: true, allowPermanent: false }, config);
   }
-  app.get('/docs/page', (req, res) => {
+  app.get(['/docs/page', '/p/docs/page'], (req, res) => {
     if (req.query.locals === '1') {
       return res.status(200).json({
         viewerType: res.locals.viewerType || null,
@@ -93,7 +101,7 @@ async function createShareViaApi(origin, cookie, body = {}) {
       'X-Forwarded-Proto': 'http',
       ...(cookie ? { Cookie: cookie } : {}),
     },
-    body: JSON.stringify({ slug: 'docs/page', duration: '24h', ...body }),
+    body: JSON.stringify({ slug: 'p/docs/page', duration: '24h', ...body }),
   });
   assert.equal(response.status, 200);
   return response.json();
@@ -121,7 +129,7 @@ test('create share returns short URL only', async () => {
         Origin: origin,
         'X-Forwarded-Proto': 'http',
       },
-      body: JSON.stringify({ slug: 'docs/page', duration: '24h' }),
+      body: JSON.stringify({ slug: 'p/docs/page', duration: '24h' }),
     });
 
     assert.equal(response.status, 200);
@@ -147,7 +155,7 @@ test('create share ignores deprecated attachment write requests', async () => {
         Origin: origin,
         'X-Forwarded-Proto': 'http',
       },
-      body: JSON.stringify({ slug: 'docs/page', duration: '24h', canWriteAttachments: true }),
+      body: JSON.stringify({ slug: 'p/docs/page', duration: '24h', canWriteAttachments: true }),
     });
 
     assert.equal(response.status, 200);
@@ -155,7 +163,7 @@ test('create share ignores deprecated attachment write requests', async () => {
     assert.equal(body.ok, true);
     assert.equal(body.canWriteAttachments, false);
 
-    const list = await fetch(`${origin}/api/shares/docs/page`, {
+    const list = await fetch(`${origin}/api/shares/p/docs/page`, {
       headers: { 'X-Forwarded-Proto': 'http' },
     });
     assert.equal(list.status, 200);
@@ -164,6 +172,26 @@ test('create share ignores deprecated attachment write requests', async () => {
     assert.ok(created);
     assert.equal(created.canWriteAttachments, false);
     assert.equal(created.shortUrl, `${origin}/s/${created.tokenId}`);
+  } finally {
+    server.close();
+  }
+});
+
+test('create share rejects unregistered content slugs', async () => {
+  const { server, origin } = await makeServer();
+  try {
+    const response = await fetch(`${origin}/api/share`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: origin,
+        'X-Forwarded-Proto': 'http',
+      },
+      body: JSON.stringify({ slug: 'p/docs/missing', duration: '24h' }),
+    });
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: 'Page not found' });
   } finally {
     server.close();
   }
@@ -180,7 +208,7 @@ test('patch cannot upgrade share attachment permission and can keep read-only st
     let body = await response.json();
     assert.deepEqual(body, { error: 'Public attachment writes are deprecated' });
 
-    let list = await fetch(`${origin}/api/shares/docs/page`, { headers: { Cookie: cookie } });
+    let list = await fetch(`${origin}/api/shares/p/docs/page`, { headers: { Cookie: cookie } });
     assert.equal(list.status, 200);
     let listed = await list.json();
     let updated = listed.shares.find(share => share.tokenId === readOnly.tokenId);
@@ -195,7 +223,7 @@ test('patch cannot upgrade share attachment permission and can keep read-only st
     assert.equal(body.tokenId, editable.tokenId);
     assert.equal(body.canWriteAttachments, false);
 
-    list = await fetch(`${origin}/api/shares/docs/page`, { headers: { Cookie: cookie } });
+    list = await fetch(`${origin}/api/shares/p/docs/page`, { headers: { Cookie: cookie } });
     assert.equal(list.status, 200);
     listed = await list.json();
     updated = listed.shares.find(share => share.tokenId === editable.tokenId);
@@ -263,7 +291,7 @@ test('short share URL sets access cookie and renders clean page in place', async
         Origin: origin,
         'X-Forwarded-Proto': 'http',
       },
-      body: JSON.stringify({ slug: 'docs/page', duration: '24h' }),
+      body: JSON.stringify({ slug: 'p/docs/page', duration: '24h' }),
     });
     const share = await create.json();
 
@@ -273,7 +301,7 @@ test('short share URL sets access cookie and renders clean page in place', async
     const setCookie = redirect.headers.get('set-cookie');
     assert.match(setCookie, /__Host-share_access=/);
     assert.doesNotMatch(setCookie, /__Host-share_scope=/);
-    assert.match(await redirect.text(), /<base href="\/docs\/page">/);
+    assert.match(await redirect.text(), /<base href="\/p\/docs\/page">/);
   } finally {
     server.close();
   }
@@ -315,7 +343,7 @@ test('auth middleware allows short share URL cookies to access target page', asy
         'X-Forwarded-Proto': 'http',
         Cookie: cookie,
       },
-      body: JSON.stringify({ slug: 'docs/page', duration: '24h' }),
+      body: JSON.stringify({ slug: 'p/docs/page', duration: '24h' }),
     });
     assert.equal(create.status, 200);
     const share = await create.json();
@@ -325,7 +353,7 @@ test('auth middleware allows short share URL cookies to access target page', asy
     assert.doesNotMatch(await direct.text(), /login/);
     const cookies = cookieHeader(direct.headers.get('set-cookie'));
 
-    const page = await fetch(`${origin}/docs/page`, {
+    const page = await fetch(`${origin}/p/docs/page`, {
       redirect: 'manual',
       headers: { Cookie: cookies },
     });
@@ -355,7 +383,7 @@ test('auth middleware keeps short share cookies read-only', async () => {
         'X-Forwarded-Proto': 'http',
         Cookie: cookie,
       },
-      body: JSON.stringify({ slug: 'docs/page', duration: '24h', canWriteAttachments: true }),
+      body: JSON.stringify({ slug: 'p/docs/page', duration: '24h', canWriteAttachments: true }),
     });
     assert.equal(create.status, 200);
     const share = await create.json();
@@ -364,7 +392,7 @@ test('auth middleware keeps short share cookies read-only', async () => {
     assert.equal(direct.status, 200);
     const cookies = cookieHeader(direct.headers.get('set-cookie'));
 
-    const appCheck = await fetch(`${origin}/docs/page?locals=1`, {
+    const appCheck = await fetch(`${origin}/p/docs/page?locals=1`, {
       headers: { Cookie: cookies },
     });
     assert.equal(appCheck.status, 200);

--- a/test/state-api.test.js
+++ b/test/state-api.test.js
@@ -16,6 +16,7 @@ const { setupShareApi } = await import('../src/routes/share-api.js');
 const { setupStateApi, RAW_BODY_LIMIT_BYTES, VALUE_JSON_LIMIT_BYTES } = await import('../src/routes/state-api.js');
 const { createShare, revokeShare } = await import('../src/sharing/share-manager.js');
 const { getPagesDb } = await import('../src/db/pages-db.js');
+const { registerLogicalPage } = await import('../src/pages/page-store.js');
 const {
   deleteStateValue,
   getArtifactState,
@@ -49,10 +50,17 @@ async function withServer(authConfig, fn) {
   const app = express();
   const config = {
     contentDir,
+    externalFiles: { allowedSources: { content: contentDir } },
     security: { allowRawHtml: false, maxFileSizeBytes: 1024 * 1024, renderTimeoutMs: 5000 },
     toc: { minHeadings: 3 },
     theme: { codeTheme: 'github-dark' },
   };
+  registerLogicalPage({
+    uri: 'short-state',
+    title: 'Short state',
+    sourcePath: path.join(contentDir, 'short-state.html'),
+    component: 'content',
+  }, config);
   setupAuth(app, authConfig || { enabled: false, password: null });
   setupShareApi(app, { enabled: true, allowPermanent: false }, config);
   setupStateApi(app);


### PR DESCRIPTION
## Summary
- require page rendering to resolve through registered logical pages only
- make raw Markdown and share creation validate registered logical page records
- update route/security tests to register fixtures explicitly and cover unregistered 404 behavior

## Tests
- npm test -- test/attachment-api.test.js test/state-api.test.js test/external-files.test.js
- npm test -- test/html-artifacts.test.js test/raw-api.test.js test/share-api.test.js test/asset-route.test.js test/auth-routes.test.js test/attachment-api.test.js test/state-api.test.js test/external-files.test.js
- git diff --check
- npm test