### PR TITLE
fix: restrict assets to registered pages

### DIFF
--- a/src/pages/asset-resolver.js
+++ b/src/pages/asset-resolver.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { getLogicalPage } from './page-store.js';
-import { resolvePageDescriptor } from '../security/pathGuard.js';
 import { getMimeType, isAssetExtension } from '../utils/mime.js';
 import { normalizeSlug } from '../utils/slug.js';
 import {
@@ -93,18 +92,11 @@ export function rewriteRelativeAssetRefs(html, { baseUrl = '', pageUri }) {
 }
 
 async function pageSourceForAsset(pageUri, config = {}) {
-  const page = getLogicalPage(pageUri);
+  const normalizedUri = normalizeSlug(pageUri);
+  const logicalUri = normalizedUri.startsWith('p/') ? normalizedUri.slice(2) : normalizedUri;
+  const page = getLogicalPage(logicalUri);
   if (page) return { sourcePath: page.sourcePath };
-  if (!config.contentDir) {
-    throw new AssetResolutionError(404, 'Page not found');
-  }
-  try {
-    const descriptor = await resolvePageDescriptor(pageUri, config.contentDir);
-    return { sourcePath: descriptor.filePath };
-  } catch (err) {
-    if (err.statusCode) throw new AssetResolutionError(err.statusCode, err.message);
-    throw new AssetResolutionError(404, 'Page not found');
-  }
+  throw new AssetResolutionError(404, 'Page not found');
 }
 
 export async function resolveLogicalAsset(pageUri, rawRelativePath, options = {}) {

--- a/src/routes/asset.js
+++ b/src/routes/asset.js
@@ -1,52 +1,7 @@
-// Static asset route for files served from the pages content directory.
-
-import { readFile, stat } from 'node:fs/promises';
-import path from 'node:path';
-import { resolveAssetPath } from '../security/pathGuard.js';
-import { isAssetExtension } from '../utils/mime.js';
-import { generateEtag } from '../utils/etag.js';
-import { logger } from '../utils/logger.js';
-
-function isAssetSlug(slug) {
-  return isAssetExtension(path.extname(slug).toLowerCase());
-}
+// Legacy contentDir asset route intentionally disabled. Page-owned assets are
+// served through /assets/:uri only after resolving a registered logical page.
 
 export function setupAssetRoute(app, config) {
-  app.get('*', async (req, res, next) => {
-    const rawSlug = req.path.slice(1) || '';
-    if (!isAssetSlug(rawSlug)) return next();
-
-    try {
-      const { filePath, mimeType } = resolveAssetPath(rawSlug, config.contentDir);
-      const info = await stat(filePath);
-      const maxFileSizeBytes = config.security?.maxFileSizeBytes ?? 1048576;
-      if (info.size > maxFileSizeBytes) {
-        return res.status(413).send(`File too large: ${info.size} bytes (max ${maxFileSizeBytes})`);
-      }
-
-      const content = await readFile(filePath);
-      const etag = generateEtag(content);
-      res.setHeader('Content-Type', mimeType);
-      res.setHeader('ETag', etag);
-      res.setHeader('Cache-Control', res.locals.viewerType === 'share' ? 'no-store' : 'public, max-age=3600');
-
-      if (req.headers['if-none-match'] === etag) {
-        logger.info('asset served', { path: rawSlug, status: 304, viewer: res.locals.viewerType === 'share' ? 'share' : 'auth' });
-        return res.status(304).end();
-      }
-
-      logger.info('asset served', { path: rawSlug, status: 200, viewer: res.locals.viewerType === 'share' ? 'share' : 'auth' });
-      return res.send(content);
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        logger.info('asset not found', { path: rawSlug });
-        return res.status(404).send('Asset not found');
-      }
-      if (err.statusCode) {
-        logger.warn('asset path rejected', { path: rawSlug, status: err.statusCode, err: err.message });
-        return res.status(err.statusCode).send(err.message);
-      }
-      return next(err);
-    }
-  });
+  void app;
+  void config;
 }

--- a/src/routes/logical-assets.js
+++ b/src/routes/logical-assets.js
@@ -11,7 +11,7 @@ export function setupLogicalAssetRoute(app, config) {
     if (!pageUri || typeof assetPath !== 'string') return next();
 
     try {
-      const signedRequest = typeof req.query.exp === 'string' || typeof req.query.sig === 'string';
+      const signedRequest = typeof req.query.exp === 'string' && typeof req.query.sig === 'string';
       const ownerDirectView = res.locals.authenticated === true;
       const { filePath, mimeType } = await resolveLogicalAsset(pageUri, assetPath, {
         config,

--- a/src/security/pathGuard.js
+++ b/src/security/pathGuard.js
@@ -1,7 +1,6 @@
 // Path traversal protection (P0-1)
 
 import { resolve, relative, extname } from 'node:path';
-import { getMimeType, isAssetExtension } from '../utils/mime.js';
 import { getLogicalPage } from '../pages/page-store.js';
 
 export class PathViolationError extends Error {
@@ -94,33 +93,4 @@ export async function resolvePageDescriptor(slug, contentRoot) {
 export function resolveSafePath(slug, contentRoot) {
   validateSlug(slug);
   return resolveCandidate(slug, contentRoot, '.md');
-}
-
-/**
- * Resolve an allowlisted static asset path within the content root.
- */
-export function resolveAssetPath(slug, contentRoot) {
-  validateSlug(slug);
-
-  const extension = extname(slug).toLowerCase();
-  if (!isAssetExtension(extension)) {
-    const err = new Error('Asset not found');
-    err.code = 'ENOENT';
-    throw err;
-  }
-
-  const candidate = resolve(contentRoot, slug);
-  const rel = relative(contentRoot, candidate);
-  if (rel.startsWith('..') || resolve(contentRoot, rel) !== candidate) {
-    throw new PathViolationError('Invalid path: outside content root');
-  }
-
-  if (extname(candidate).toLowerCase() !== extension) {
-    throw new PathViolationError('Invalid path: extension mismatch');
-  }
-
-  return {
-    filePath: candidate,
-    mimeType: getMimeType(extension),
-  };
 }

--- a/test/asset-route.test.js
+++ b/test/asset-route.test.js
@@ -152,41 +152,55 @@ async function rawGet(origin, requestPath) {
   });
 }
 
-test('asset route serves allowlisted assets with MIME, ETag, 304, and size limit', async () => {
+test('logical asset route serves registered page assets with MIME, ETag, 304, and size limit', async () => {
   const contentDir = await makeContentDir();
   try {
+    const config = baseConfig(contentDir);
+    const pagePath = path.join(contentDir, 'page.md');
+    await writeFile(pagePath, '# Page\n');
     await writeFile(path.join(contentDir, 'image.jpg'), Buffer.from([0xff, 0xd8, 0xff]));
     await writeFile(path.join(contentDir, 'image.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
     await writeFile(path.join(contentDir, 'style.css'), 'body { color: red; }\n');
     await writeFile(path.join(contentDir, 'doc.pdf'), Buffer.from('%PDF-1.4\n'));
     await writeFile(path.join(contentDir, 'large.jpg'), Buffer.alloc(1025));
     await writeFile(path.join(contentDir, 'tool.exe'), 'not allowed');
+    registerPage(config, 'page', pagePath, 'Page');
 
-    await withServer(baseConfig(contentDir), async ({ origin }) => {
-      let res = await fetch(`${origin}/image.jpg`);
+    await withServer(config, async ({ origin }) => {
+      let res = await fetch(`${origin}/assets/page?path=image.jpg`);
       assert.equal(res.status, 200);
       assert.equal(res.headers.get('content-type'), 'image/jpeg');
       assert.equal(res.headers.get('cache-control'), 'public, max-age=3600');
       const etag = res.headers.get('etag');
       assert.ok(etag);
 
-      res = await fetch(`${origin}/image.jpg`, { headers: { 'If-None-Match': etag } });
+      res = await fetch(`${origin}/assets/p/page?path=image.jpg`);
+      assert.equal(res.status, 200);
+      assert.equal(Buffer.from(await res.arrayBuffer()).toString('hex'), 'ffd8ff');
+
+      res = await fetch(`${origin}/assets/page?path=image.jpg`, { headers: { 'If-None-Match': etag } });
       assert.equal(res.status, 304);
       assert.equal(res.headers.get('etag'), etag);
 
-      res = await fetch(`${origin}/image.png`);
+      res = await fetch(`${origin}/assets/page?path=image.png`);
       assert.equal(res.headers.get('content-type'), 'image/png');
 
-      res = await fetch(`${origin}/style.css`);
+      res = await fetch(`${origin}/assets/page?path=style.css`);
       assert.equal(res.headers.get('content-type'), 'text/css; charset=utf-8');
 
-      res = await fetch(`${origin}/doc.pdf`);
+      res = await fetch(`${origin}/assets/page?path=doc.pdf`);
       assert.equal(res.headers.get('content-type'), 'application/pdf');
 
-      res = await fetch(`${origin}/large.jpg`);
+      res = await fetch(`${origin}/assets/page?path=large.jpg`);
       assert.equal(res.status, 413);
 
-      res = await fetch(`${origin}/tool.exe`);
+      res = await fetch(`${origin}/assets/page?path=tool.exe`);
+      assert.equal(res.status, 404);
+
+      res = await fetch(`${origin}/assets/missing?path=image.jpg`);
+      assert.equal(res.status, 404);
+
+      res = await fetch(`${origin}/image.jpg`);
       assert.equal(res.status, 404);
     });
   } finally {
@@ -232,19 +246,29 @@ test('root route serves admin console and /admin is not mounted', async () => {
 test('asset route follows auth wall, session auth, and method boundaries', async () => {
   const contentDir = await makeContentDir();
   try {
+    const config = baseConfig(contentDir, { enabled: true, password: hashPassword('secret') });
+    const pagePath = path.join(contentDir, 'private.md');
+    await writeFile(pagePath, '# Private\n');
     await writeFile(path.join(contentDir, 'private.jpg'), 'private');
+    registerPage(config, 'private', pagePath, 'Private');
 
-    await withServer(baseConfig(contentDir, { enabled: true, password: hashPassword('secret') }), async ({ origin }) => {
+    await withServer(config, async ({ origin }) => {
       let res = await fetch(`${origin}/private.jpg`, { redirect: 'manual' });
       expectAssetDenied(res);
 
+      res = await fetch(`${origin}/assets/private?path=private.jpg`, { redirect: 'manual' });
+      expectLoginRedirect(res);
+
       const cookie = sessionCookie(await login(origin));
-      res = await fetch(`${origin}/private.jpg`, { headers: { Cookie: cookie } });
+      res = await fetch(`${origin}/assets/private?path=private.jpg`, { headers: { Cookie: cookie } });
       assert.equal(res.status, 200);
       assert.equal(await res.text(), 'private');
 
-      res = await fetch(`${origin}/private.jpg`, { method: 'PUT', redirect: 'manual' });
-      expectAssetDenied(res);
+      res = await fetch(`${origin}/private.jpg`, { headers: { Cookie: cookie } });
+      assert.equal(res.status, 404);
+
+      res = await fetch(`${origin}/assets/private?path=private.jpg`, { method: 'PUT', redirect: 'manual' });
+      expectLoginRedirect(res);
     });
   } finally {
     await rm(contentDir, { recursive: true, force: true });
@@ -483,16 +507,20 @@ test('revoked share invalidates existing signed asset URLs', async () => {
 test('asset route rejects traversal, null byte, and double-encoded traversal', async () => {
   const contentDir = await makeContentDir();
   try {
+    const config = baseConfig(contentDir);
+    const pagePath = path.join(contentDir, 'page.md');
+    await writeFile(pagePath, '# Page\n');
+    registerPage(config, 'page', pagePath, 'Page');
     const share = createShare('page', '24h', { allowPermanent: false });
     const cookie = `${SHARE_SCOPE_COOKIE_NAME}=${createShareScopeCookie('page', share.tokenId, Date.now() + 3600_000).value}`;
-    await withServer(baseConfig(contentDir), async ({ origin }) => {
-      let res = await rawGet(origin, '/%2e%2e/secret.jpg');
+    await withServer(config, async ({ origin }) => {
+      let res = await rawGet(origin, '/assets/page?path=%2e%2e%2Fsecret.jpg');
       assert.equal(res.statusCode, 400);
 
-      res = await rawGet(origin, '/bad%00slug.jpg');
+      res = await rawGet(origin, '/assets/page?path=bad%00slug.jpg');
       assert.equal(res.statusCode, 400);
 
-      res = await rawGet(origin, '/%252e%252e/secret.jpg');
+      res = await rawGet(origin, '/assets/page?path=%252e%252e%2Fsecret.jpg');
       assert.equal(res.statusCode, 400);
 
       res = await fetch(`${origin}/%E0%A4%A.jpg`, {


### PR DESCRIPTION
## Summary
- disable the legacy contentDir asset catch-all so direct asset paths like /image.jpg no longer bypass the logical page registry
- require /assets/:uri?path=... requests to resolve a registered logical page, including canonical p/ URIs
- require both exp and sig before treating an asset request as signed, and remove the unused resolveAssetPath helper

## Validation
- npm test -- test/asset-route.test.js test/external-files.test.js
- npm test
- npm run build:admin
- git diff --check