### PR TITLE
fix: deprecate legacy share token bypass

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -50,6 +50,7 @@ export const DEFAULT_CONFIG = {
   sharing: {
     enabled: true,
     allowPermanent: false,
+    legacyTokenAccess: true,
   },
   attachments: {
     maxFileSizeBytes: 5 * 1024 * 1024,

--- a/src/security/auth.js
+++ b/src/security/auth.js
@@ -27,6 +27,7 @@ const SESSION_IDLE_MS = 3_600_000;            // 60 minutes
 const REMEMBER_ABSOLUTE_MS = 30 * 86_400_000; // 30 days
 const REMEMBER_IDLE_MS = 7 * 86_400_000;      // 7 days
 const CLEANUP_INTERVAL_MS = 300_000;          // 5 minutes
+const LEGACY_SHARE_TOKEN_REMOVAL_DATE = '2026-10-01';
 
 // --- SQLite session store ---
 
@@ -229,6 +230,18 @@ function acceptShareViewer(res, result, options = {}) {
   }
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Referrer-Policy', 'no-referrer');
+}
+
+function logLegacyShareTokenAccepted(req, surface, artifact, result) {
+  logger.warn('legacy share token accepted', {
+    path: req.path,
+    surface,
+    artifact,
+    tokenId: result.tokenId,
+    ip: getClientIp(req),
+    deprecation: '?token= share access is deprecated; use /s/<tokenId> short share links',
+    removalDate: LEGACY_SHARE_TOKEN_REMOVAL_DATE,
+  });
 }
 
 // --- Brute-force protection ---
@@ -580,6 +593,7 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
     if (authDisabled) return next();
 
     const shortShareEnabled = sharingConfig?.enabled !== false;
+    const legacyTokenAccessEnabled = shortShareEnabled && sharingConfig?.legacyTokenAccess !== false;
     if (req.path.startsWith('/_assets')
         || (shortShareEnabled && /^\/s\/[a-f0-9]{32}$/.test(req.path))
         || req.path === loginPath || req.path === logoutPath) {
@@ -612,13 +626,15 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
 
     // Legacy long-token bypass. This is retained only for old links; new share
     // creation and short-link access no longer expose or require this URL shape.
-    if ((req.method === 'GET' || req.method === 'HEAD') && req.query.token
+    if (legacyTokenAccessEnabled
+        && (req.method === 'GET' || req.method === 'HEAD') && req.query.token
         && !req.path.startsWith('/api/')
         && !isAssetPath(req.path)
         && req.path !== '/') {
       const slug = req.path.slice(1);
       const result = verifyShare(req.query.token, slug);
       if (result.valid) {
+        logLegacyShareTokenAccepted(req, 'page', slug, result);
         acceptShareViewer(res, result, { refreshAccessCookie: true });
         return next();
       }
@@ -637,13 +653,15 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       }
     }
 
-    if (req.query.token && (req.path.startsWith('/api/state/') || isAttachmentApi(req))) {
+    if (legacyTokenAccessEnabled
+        && req.query.token && (req.path.startsWith('/api/state/') || isAttachmentApi(req))) {
       const artifact = artifactFromApiPath(req.path);
       let result = { valid: false };
       try {
         if (artifact) result = verifyShare(req.query.token, artifact);
       } catch { /* malformed encoding — treat as invalid */ }
       if (result.valid) {
+        logLegacyShareTokenAccepted(req, req.path.startsWith('/api/state/') ? 'state-api' : 'attachment-api', artifact, result);
         acceptShareViewer(res, result);
         return next();
       }

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -26,7 +26,7 @@ function cookieHeader(setCookie) {
     .join('; ');
 }
 
-function makeServer({ auth = false, authConfig = null, sharingEnabled = true, shareViewer = false } = {}) {
+function makeServer({ auth = false, authConfig = null, sharingEnabled = true, legacyTokenAccess = true, shareViewer = false } = {}) {
   const contentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-pages-share-content-'));
   fs.mkdirSync(path.join(contentDir, 'docs'), { recursive: true });
   fs.writeFileSync(path.join(contentDir, 'docs', 'page.html'), '<!doctype html><head><title>Shared page</title></head><h1>Shared page</h1>');
@@ -48,7 +48,7 @@ function makeServer({ auth = false, authConfig = null, sharingEnabled = true, sh
     setupAuth(app, authConfig || {
       enabled: true,
       password: hashPassword('secret'),
-    }, { enabled: sharingEnabled });
+    }, { enabled: sharingEnabled, legacyTokenAccess });
   }
   if (shareViewer) {
     app.use((_req, res, next) => {
@@ -400,6 +400,28 @@ test('auth middleware keeps short share cookies read-only', async () => {
       viewerType: 'share',
       shareCanWriteAttachments: false,
     });
+  } finally {
+    server.close();
+  }
+});
+
+test('legacy long share token bypass can be disabled while short links still work', async () => {
+  const { server, origin } = await makeServer({ auth: true, legacyTokenAccess: false });
+  try {
+    const share = createShare('docs/page', '24h', { allowPermanent: false });
+
+    let response = await fetch(`${origin}/docs/page?token=${encodeURIComponent(share.token)}`, {
+      redirect: 'manual',
+    });
+    assert.equal(response.status, 302);
+    assert.equal(
+      response.headers.get('location'),
+      `/login?next=${encodeURIComponent(`/docs/page?token=${encodeURIComponent(share.token)}`)}`
+    );
+
+    response = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('set-cookie'), /__Host-share_access=/);
   } finally {
     server.close();
   }


### PR DESCRIPTION
## Summary
- gate legacy long `?token=` share bypass behind `sharing.legacyTokenAccess`
- log accepted legacy-token hits with surface, artifact, tokenId, deprecation guidance, and removal date `2026-10-01`
- keep `/s/<tokenId>` short links working when legacy long-token access is disabled

## Rebase
Rebased onto `main` after W4 merge commit `e3c4e60`.

## Validation
- `npm test -- test/share-api.test.js test/auth-routes.test.js test/attachment-api.test.js test/html-artifacts.test.js` -> 44/44 pass
- `npm test` -> 103/103 pass
- `npm run build:admin` -> pass
- `git diff --check` -> pass
