### PR TITLE
fix: normalize share asset signature slugs

### DIFF
--- a/src/sharing/share-manager.js
+++ b/src/sharing/share-manager.js
@@ -260,6 +260,11 @@ function computeShareAssetHmac(uri, realPath, expiresAt, tokenId, secret) {
     .digest('hex');
 }
 
+function normalizeShareAssetSlug(slug) {
+  const normalized = normalizeSlug(slug);
+  return normalized.startsWith('p/') ? normalized.slice(2) : normalized;
+}
+
 function isAssetWithinScope(assetPath, directory) {
   const normalizedAsset = normalizeSlug(assetPath);
   const assetDir = directoryScope(normalizedAsset);
@@ -470,7 +475,7 @@ export function verifyShareAssetSignature({ uri, realPath, expiresAt, tokenId, s
   if (!isTokenId(actualTokenId)) return { valid: false };
   if (nowMs() > exp) return { valid: false };
   const record = activeShareRecord(actualTokenId);
-  if (!record || normalizeSlug(record.slug) !== normalizeSlug(uri)) return { valid: false };
+  if (!record || normalizeShareAssetSlug(record.slug) !== normalizeShareAssetSlug(uri)) return { valid: false };
   if (record.expiresAt !== 0 && exp > record.expiresAt) return { valid: false };
 
   const expected = computeShareAssetHmac(uri, realPath, exp, actualTokenId, getSecret());

--- a/test/asset-route.test.js
+++ b/test/asset-route.test.js
@@ -446,6 +446,32 @@ test('signed share assets allow page assets while isolating unsigned siblings', 
   }
 });
 
+test('signed share assets work for p-prefixed logical page shares', async () => {
+  const contentDir = await makeContentDir();
+  try {
+    const config = baseConfig(contentDir, { enabled: true, password: hashPassword('secret') });
+    await mkdir(path.join(contentDir, 'docs'));
+    const pagePath = path.join(contentDir, 'docs', 'prefixed.html');
+    await writeFile(pagePath, '<!doctype html><img src="hero.png">');
+    await writeFile(path.join(contentDir, 'docs', 'hero.png'), 'hero');
+    registerPage(config, 'docs/prefixed', pagePath, 'Prefixed');
+    const share = createShare('p/docs/prefixed', '24h', { allowPermanent: false });
+
+    await withServer(config, async ({ origin }) => {
+      const page = await fetch(`${origin}/s/${share.tokenId}`);
+      assert.equal(page.status, 200);
+      const signedPath = signedAssetPath(await page.text(), 'hero.png');
+
+      const res = await fetch(`${origin}${signedPath}`);
+      assert.equal(res.status, 200);
+      assert.equal(await res.text(), 'hero');
+      assert.equal(res.headers.get('cache-control'), 'no-store');
+    });
+  } finally {
+    await rm(contentDir, { recursive: true, force: true });
+  }
+});
+
 test('expired and tampered share-scope cookies fall through to auth wall', async () => {
   const contentDir = await makeContentDir();
   try {


### PR DESCRIPTION
## Summary
- normalize `p/` logical route prefixes when matching share records during signed asset verification
- keep the existing signed asset HMAC input, token, expiry, and active-share checks intact
- add a regression for `/s/<tokenId>` rendering of a `p/`-prefixed share whose signed image asset must return 200

## Validation
- npm test -- test/asset-route.test.js
- npm test -- test/asset-route.test.js test/share-api.test.js test/auth-routes.test.js test/html-artifacts.test.js
- npm test
- npm run build:admin
- git diff --check

## Notes
- Based on main containing W6 (`93a5e47e`).
- Scope is limited to share asset signature slug matching and regression coverage.