### PR TITLE
fix: remove legacy share token bypass

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -50,7 +50,6 @@ export const DEFAULT_CONFIG = {
   sharing: {
     enabled: true,
     allowPermanent: false,
-    legacyTokenAccess: true,
   },
   attachments: {
     maxFileSizeBytes: 5 * 1024 * 1024,

--- a/src/routes/attachment-api.js
+++ b/src/routes/attachment-api.js
@@ -68,10 +68,7 @@ function requireAttachmentMutation(req, res, artifact) {
 
 function attachmentResponse(req, record) {
   const browserBase = browserBaseFromRequest(req);
-  let fileUrl = browserPath(browserBase, `api/attachments/${encodeURIComponent(record.artifact)}/${record.attachmentId}/file`);
-  if (typeof req.query.token === 'string' && req.query.token) {
-    fileUrl = `${fileUrl}?${new URLSearchParams({ token: req.query.token }).toString()}`;
-  }
+  const fileUrl = browserPath(browserBase, `api/attachments/${encodeURIComponent(record.artifact)}/${record.attachmentId}/file`);
   return {
     attachmentId: record.attachmentId,
     artifact: record.artifact,

--- a/src/security/auth.js
+++ b/src/security/auth.js
@@ -13,7 +13,6 @@ import {
   clearShareAccessCookieHeader,
   clearShareScopeCookieHeader,
   createShareAccessCookie,
-  verifyShare,
   verifyShareAccessCookie,
 } from '../sharing/share-manager.js';
 import { browserBaseFromRequest, browserPath, browserRoot, isPathWithinBase } from '../lib/browser-base.js';
@@ -27,7 +26,6 @@ const SESSION_IDLE_MS = 3_600_000;            // 60 minutes
 const REMEMBER_ABSOLUTE_MS = 30 * 86_400_000; // 30 days
 const REMEMBER_IDLE_MS = 7 * 86_400_000;      // 7 days
 const CLEANUP_INTERVAL_MS = 300_000;          // 5 minutes
-const LEGACY_SHARE_TOKEN_REMOVAL_DATE = '2026-10-01';
 
 // --- SQLite session store ---
 
@@ -230,18 +228,6 @@ function acceptShareViewer(res, result, options = {}) {
   }
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Referrer-Policy', 'no-referrer');
-}
-
-function logLegacyShareTokenAccepted(req, surface, artifact, result) {
-  logger.warn('legacy share token accepted', {
-    path: req.path,
-    surface,
-    artifact,
-    tokenId: result.tokenId,
-    ip: getClientIp(req),
-    deprecation: '?token= share access is deprecated; use /s/<tokenId> short share links',
-    removalDate: LEGACY_SHARE_TOKEN_REMOVAL_DATE,
-  });
 }
 
 // --- Brute-force protection ---
@@ -593,7 +579,6 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
     if (authDisabled) return next();
 
     const shortShareEnabled = sharingConfig?.enabled !== false;
-    const legacyTokenAccessEnabled = shortShareEnabled && sharingConfig?.legacyTokenAccess !== false;
     if (req.path.startsWith('/_assets')
         || (shortShareEnabled && /^\/s\/[a-f0-9]{32}$/.test(req.path))
         || req.path === loginPath || req.path === logoutPath) {
@@ -624,23 +609,6 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       }
     }
 
-    // Legacy long-token bypass. This is retained only for old links; new share
-    // creation and short-link access no longer expose or require this URL shape.
-    if (legacyTokenAccessEnabled
-        && (req.method === 'GET' || req.method === 'HEAD') && req.query.token
-        && !req.path.startsWith('/api/')
-        && !isAssetPath(req.path)
-        && req.path !== '/') {
-      const slug = req.path.slice(1);
-      const result = verifyShare(req.query.token, slug);
-      if (result.valid) {
-        logLegacyShareTokenAccepted(req, 'page', slug, result);
-        acceptShareViewer(res, result, { refreshAccessCookie: true });
-        return next();
-      }
-      logger.info('share token invalid', { path: req.path, ip: getClientIp(req) });
-    }
-
     if (req.path.startsWith('/api/state/') || isAttachmentApi(req)) {
       const artifact = artifactFromApiPath(req.path);
       let result = { valid: false };
@@ -651,21 +619,6 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
         acceptShareViewer(res, result);
         return next();
       }
-    }
-
-    if (legacyTokenAccessEnabled
-        && req.query.token && (req.path.startsWith('/api/state/') || isAttachmentApi(req))) {
-      const artifact = artifactFromApiPath(req.path);
-      let result = { valid: false };
-      try {
-        if (artifact) result = verifyShare(req.query.token, artifact);
-      } catch { /* malformed encoding — treat as invalid */ }
-      if (result.valid) {
-        logLegacyShareTokenAccepted(req, req.path.startsWith('/api/state/') ? 'state-api' : 'attachment-api', artifact, result);
-        acceptShareViewer(res, result);
-        return next();
-      }
-      logger.info('api share token invalid', { path: req.path, ip: getClientIp(req) });
     }
 
     if (validateSession(getSessionCookie(req))) {

--- a/test/asset-route.test.js
+++ b/test/asset-route.test.js
@@ -415,10 +415,10 @@ test('signed share assets allow page assets while isolating unsigned siblings', 
     await writeFile(path.join(contentDir, 'root.png'), 'root');
     await writeFile(path.join(contentDir, 'other', 'secret.png'), 'secret');
     registerPage(config, 'docs/guide', pagePath, 'Guide');
-    const token = createShare('docs/guide', '24h', { allowPermanent: false }).token;
+    const share = createShare('docs/guide', '24h', { allowPermanent: false });
 
     await withServer(config, async ({ origin }) => {
-      const page = await fetch(`${origin}/docs/guide?token=${encodeURIComponent(token)}`);
+      const page = await fetch(`${origin}/s/${share.tokenId}`);
       assert.equal(page.status, 200);
       const body = await page.text();
       const signedPath = signedAssetPath(body, 'diagram.png');
@@ -512,7 +512,7 @@ test('revoked share invalidates existing signed asset URLs', async () => {
     const share = createShare('shared', '24h', { allowPermanent: false });
 
     await withServer(config, async ({ origin }) => {
-      const page = await fetch(`${origin}/shared?token=${encodeURIComponent(share.token)}`);
+      const page = await fetch(`${origin}/s/${share.tokenId}`);
       assert.equal(page.status, 200);
       const signedPath = signedAssetPath(await page.text(), 'asset.jpg');
 

--- a/test/attachment-api.test.js
+++ b/test/attachment-api.test.js
@@ -323,13 +323,10 @@ test('share viewers can list and read matching artifact attachments but cannot m
       });
       assert.equal(res.status, 403);
 
-      res = await fetch(`${origin}/api/attachments/renovation-checklist/share-log?token=${encodeURIComponent(share.token)}`);
-      assert.equal(res.status, 200);
-      const legacyList = await res.json();
-      assert.match(legacyList.attachments[0].fileUrl, /\?token=/);
-
-      res = await fetch(`${origin}${legacyList.attachments[0].fileUrl}`, { redirect: 'manual' });
-      assert.equal(res.status, 200);
+      res = await fetch(`${origin}/api/attachments/renovation-checklist/share-log?token=${encodeURIComponent(share.token)}`, {
+        redirect: 'manual',
+      });
+      expectLoginRedirect(res);
     });
   } finally {
     await rm(contentDir, { recursive: true, force: true });
@@ -398,7 +395,7 @@ test('existing short share cookie sessions cannot be upgraded to attachment writ
   }
 });
 
-test('legacy tokens remain read-only even when created with deprecated write permission', async () => {
+test('legacy tokens no longer authorize attachment access', async () => {
   const contentDir = await makeContentDir();
   try {
     const readOnly = createShare('renovation-checklist', '24h', { allowPermanent: false });
@@ -407,17 +404,19 @@ test('legacy tokens remain read-only even when created with deprecated write per
     await withServer(baseConfig(contentDir), async ({ origin }) => {
       let res = await fetch(`${origin}/api/attachments/renovation-checklist/legacy-readonly?token=${encodeURIComponent(readOnly.token)}`, {
         method: 'POST',
+        redirect: 'manual',
         headers: { Origin: origin },
         body: formData(JPEG),
       });
-      assert.equal(res.status, 403);
+      expectLoginRedirect(res);
 
       res = await fetch(`${origin}/api/attachments/renovation-checklist/legacy-editable?token=${encodeURIComponent(editable.token)}`, {
         method: 'POST',
+        redirect: 'manual',
         headers: { Origin: origin },
         body: formData(JPEG),
       });
-      assert.equal(res.status, 403);
+      expectLoginRedirect(res);
 
       res = await fetch(`${origin}/api/attachments/notes/legacy-wrong?token=${encodeURIComponent(editable.token)}`, {
         method: 'POST',
@@ -429,9 +428,10 @@ test('legacy tokens remain read-only even when created with deprecated write per
 
       res = await fetch(`${origin}/api/attachments/renovation-checklist/not-found?token=${encodeURIComponent(readOnly.token)}`, {
         method: 'DELETE',
+        redirect: 'manual',
         headers: { Origin: origin },
       });
-      assert.equal(res.status, 403);
+      expectLoginRedirect(res);
     });
   } finally {
     await rm(contentDir, { recursive: true, force: true });

--- a/test/html-artifacts.test.js
+++ b/test/html-artifacts.test.js
@@ -212,22 +212,22 @@ test('shared html artifacts render directly while shared markdown keeps page hea
     await writeFile(sharedMarkdownPath, '# Shared Markdown\n');
     registerPage(config, 'shared', sharedPath, 'Shared');
     registerPage(config, 'shared-markdown', sharedMarkdownPath, 'Shared Markdown');
-    const htmlToken = createShare('shared', '24h', { allowPermanent: false }).token;
-    const markdownToken = createShare('shared-markdown', '24h', { allowPermanent: false }).token;
+    const htmlShare = createShare('shared', '24h', { allowPermanent: false });
+    const markdownShare = createShare('shared-markdown', '24h', { allowPermanent: false });
 
     await withServer({
       ...config,
       auth: { enabled: true, password: hashPassword('secret') },
     }, async ({ origin }) => {
-      const redirect = await fetch(`${origin}/shared.html?token=${encodeURIComponent(htmlToken)}`, { redirect: 'manual' });
-      assert.equal(redirect.status, 301);
-      assert.equal(redirect.headers.get('location'), `/shared?token=${encodeURIComponent(htmlToken)}`);
+      const redirect = await fetch(`${origin}/shared.html?token=${encodeURIComponent(htmlShare.token)}`, { redirect: 'manual' });
+      assert.equal(redirect.status, 302);
+      assert.match(redirect.headers.get('location'), /^\/login\?/);
 
-      const uppercaseRedirect = await fetch(`${origin}/shared.HTML?token=${encodeURIComponent(htmlToken)}`, { redirect: 'manual' });
-      assert.equal(uppercaseRedirect.status, 301);
-      assert.equal(uppercaseRedirect.headers.get('location'), `/shared?token=${encodeURIComponent(htmlToken)}`);
+      const uppercaseRedirect = await fetch(`${origin}/shared.HTML?token=${encodeURIComponent(htmlShare.token)}`, { redirect: 'manual' });
+      assert.equal(uppercaseRedirect.status, 302);
+      assert.match(uppercaseRedirect.headers.get('location'), /^\/login\?/);
 
-      const shared = await fetch(`${origin}/shared?token=${encodeURIComponent(htmlToken)}`);
+      const shared = await fetch(`${origin}/s/${htmlShare.tokenId}`);
       assert.equal(shared.status, 200);
       assert.equal(shared.headers.get('content-security-policy'), HTML_ARTIFACT_CSP);
       const sharedBody = await shared.text();
@@ -236,7 +236,7 @@ test('shared html artifacts render directly while shared markdown keeps page hea
       assert.doesNotMatch(sharedBody, /html-artifact-frame/);
       assert.doesNotMatch(sharedBody, /theme-toggle/);
 
-      const markdown = await fetch(`${origin}/shared-markdown?token=${encodeURIComponent(markdownToken)}`);
+      const markdown = await fetch(`${origin}/s/${markdownShare.tokenId}`);
       assert.equal(markdown.status, 200);
       assert.equal(markdown.headers.get('content-security-policy'), DEFAULT_CSP);
       const markdownBody = await markdown.text();

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -26,7 +26,7 @@ function cookieHeader(setCookie) {
     .join('; ');
 }
 
-function makeServer({ auth = false, authConfig = null, sharingEnabled = true, legacyTokenAccess = true, shareViewer = false } = {}) {
+function makeServer({ auth = false, authConfig = null, sharingEnabled = true, shareViewer = false } = {}) {
   const contentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-pages-share-content-'));
   fs.mkdirSync(path.join(contentDir, 'docs'), { recursive: true });
   fs.writeFileSync(path.join(contentDir, 'docs', 'page.html'), '<!doctype html><head><title>Shared page</title></head><h1>Shared page</h1>');
@@ -48,7 +48,7 @@ function makeServer({ auth = false, authConfig = null, sharingEnabled = true, le
     setupAuth(app, authConfig || {
       enabled: true,
       password: hashPassword('secret'),
-    }, { enabled: sharingEnabled, legacyTokenAccess });
+    }, { enabled: sharingEnabled });
   }
   if (shareViewer) {
     app.use((_req, res, next) => {
@@ -405,8 +405,8 @@ test('auth middleware keeps short share cookies read-only', async () => {
   }
 });
 
-test('legacy long share token bypass can be disabled while short links still work', async () => {
-  const { server, origin } = await makeServer({ auth: true, legacyTokenAccess: false });
+test('legacy long share token bypass is rejected while short links still work', async () => {
+  const { server, origin } = await makeServer({ auth: true });
   try {
     const share = createShare('docs/page', '24h', { allowPermanent: false });
 

--- a/test/state-api.test.js
+++ b/test/state-api.test.js
@@ -271,37 +271,29 @@ test('state API CSRF checks mutating requests only', async () => {
   });
 });
 
-test('state API allows share-token CRUD for the matching artifact', async () => {
+test('state API rejects legacy share-token CRUD for the matching artifact', async () => {
   const token = createShare('shared-state', '24h', { allowPermanent: false }).token;
 
   await withServer(authConfig(), async ({ origin }) => {
-    let res = await fetch(`${origin}/api/state/shared-state?token=${encodeURIComponent(token)}`);
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get('cache-control'), 'no-store');
-    assert.equal(res.headers.get('referrer-policy'), 'no-referrer');
-    assert.deepEqual(await res.json(), { ok: true, state: {} });
+    let res = await fetch(`${origin}/api/state/shared-state?token=${encodeURIComponent(token)}`, {
+      redirect: 'manual',
+    });
+    expectLoginRedirect(res);
 
     res = await fetch(`${origin}/api/state/shared-state/checklist?token=${encodeURIComponent(token)}`, {
       method: 'PUT',
+      redirect: 'manual',
       headers: sameOriginHeaders(origin),
       body: JSON.stringify({ value: { done: true } }),
     });
-    assert.equal(res.status, 200);
-    assert.deepEqual(await res.json(), { ok: true, key: 'checklist', value: { done: true } });
-
-    res = await fetch(`${origin}/api/state/shared-state/checklist?token=${encodeURIComponent(token)}`);
-    assert.equal(res.status, 200);
-    assert.deepEqual(await res.json(), { ok: true, key: 'checklist', value: { done: true } });
+    expectLoginRedirect(res);
 
     res = await fetch(`${origin}/api/state/shared-state/checklist?token=${encodeURIComponent(token)}`, {
       method: 'DELETE',
+      redirect: 'manual',
       headers: { Origin: origin },
     });
-    assert.equal(res.status, 200);
-    assert.deepEqual(await res.json(), { ok: true });
-
-    res = await fetch(`${origin}/api/state/shared-state/checklist?token=${encodeURIComponent(token)}`);
-    assert.equal(res.status, 404);
+    expectLoginRedirect(res);
   });
 });
 
@@ -357,30 +349,31 @@ test('state API share-token scope mismatch falls through to auth wall', async ()
   });
 });
 
-test('state API still enforces CSRF for share-token mutating requests', async () => {
+test('state API rejects legacy share-token mutating requests before CSRF handling', async () => {
   const token = createShare('share-csrf', '24h', { allowPermanent: false }).token;
 
   await withServer(authConfig(), async ({ origin }) => {
     let res = await fetch(`${origin}/api/state/share-csrf/key?token=${encodeURIComponent(token)}`, {
       method: 'PUT',
+      redirect: 'manual',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ value: true }),
     });
-    assert.equal(res.status, 403);
-    assert.deepEqual(await res.json(), { error: 'CSRF validation failed: missing Origin/Referer' });
+    expectLoginRedirect(res);
 
     res = await fetch(`${origin}/api/state/share-csrf/key?token=${encodeURIComponent(token)}`, {
       method: 'PUT',
+      redirect: 'manual',
       headers: sameOriginHeaders(origin),
       body: JSON.stringify({ value: true }),
     });
-    assert.equal(res.status, 200);
+    expectLoginRedirect(res);
 
     res = await fetch(`${origin}/api/state/share-csrf/key?token=${encodeURIComponent(token)}`, {
       method: 'DELETE',
+      redirect: 'manual',
     });
-    assert.equal(res.status, 403);
-    assert.deepEqual(await res.json(), { error: 'CSRF validation failed: missing Origin/Referer' });
+    expectLoginRedirect(res);
   });
 });
 
@@ -430,7 +423,7 @@ test('state API auth wall redirects unauthenticated and malformed-token API requ
   });
 });
 
-test('share tokens do not grant access to raw API and page share bypass still works', async () => {
+test('legacy share tokens do not grant access to raw API or pages', async () => {
   const token = createShare('shared-page', '24h', { allowPermanent: false }).token;
   const app = express();
   setupAuth(app, authConfig());
@@ -440,9 +433,10 @@ test('share tokens do not grant access to raw API and page share bypass still wo
   });
 
   await withApp(app, async ({ origin }) => {
-    let res = await fetch(`${origin}/shared-page?token=${encodeURIComponent(token)}`);
-    assert.equal(res.status, 200);
-    assert.equal(await res.text(), 'share-viewer');
+    let res = await fetch(`${origin}/shared-page?token=${encodeURIComponent(token)}`, {
+      redirect: 'manual',
+    });
+    expectLoginRedirect(res);
 
     res = await fetch(`${origin}/api/raw/shared-page?token=${encodeURIComponent(token)}`, {
       redirect: 'manual',


### PR DESCRIPTION
## Summary
- remove legacy ?token= auth bypass handling for pages, state API, and attachment API
- remove the legacyTokenAccess config default and legacy acceptance logging/date gate
- stop propagating ?token= into attachment file URLs and update tests to require /s/<tokenId> or signed asset access

## Validation
- npm test -- test/share-api.test.js test/auth-routes.test.js test/html-artifacts.test.js test/attachment-api.test.js test/state-api.test.js test/asset-route.test.js
- npm test
- npm run build:admin
- git diff --check