### PR TITLE
Modernize Pages viewer UI

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,28 +1,44 @@
-/* zylos-pages theme — GitHub-inspired, responsive, dark/light */
+/* zylos-pages theme — restrained Pages v2, responsive, dark/light */
 
 :root {
   --color-bg: #ffffff;
-  --color-text: #1f2328;
-  --color-text-secondary: #656d76;
-  --color-border: #d0d7de;
-  --color-link: #0969da;
-  --color-link-hover: #0550ae;
-  --color-code-bg: #f6f8fa;
-  --color-code-border: #d0d7de;
-  --color-blockquote-border: #d0d7de;
-  --color-blockquote-text: #656d76;
-  --color-header-bg: #f6f8fa;
-  --color-tag-bg: #ddf4ff;
-  --color-tag-text: #0969da;
-  --color-table-border: #d0d7de;
-  --color-table-row-alt: #f6f8fa;
+  --color-panel: #ffffff;
+  --color-sidebar: #fbfbfc;
+  --color-text: #181a20;
+  --color-text-secondary: #5f6673;
+  --color-text-faint: #9298a3;
+  --color-border: #ededf0;
+  --color-border-strong: #e3e4e8;
+  --color-hover: #f4f4f6;
+  --color-link: #5b57e8;
+  --color-link-hover: #4f46e5;
+  --color-code-bg: #1a1c23;
+  --color-code-text: #e6e8ef;
+  --color-code-border: #262933;
+  --color-blockquote-border: #e0e2fb;
+  --color-blockquote-text: #5f6673;
+  --color-header-bg: rgba(255, 255, 255, 0.82);
+  --color-tag-bg: #eef0fe;
+  --color-tag-text: #6366f1;
+  --color-table-border: #e3e4e8;
+  --color-table-row-alt: #fbfbfc;
   --color-success: #1a7f37;
   --color-danger: #cf222e;
-  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --color-accent: #6366f1;
+  --color-accent-hover: #4f46e5;
+  --color-accent-soft: #eef0fe;
+  --color-accent-line: #e0e2fb;
+  --font-body: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "PingFang SC", Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
   --content-width: 800px;
   --toc-width: 220px;
-  --nav-width: 220px;
+  --nav-width: 236px;
+  --radius: 8px;
+  --radius-lg: 12px;
+  --control-height: 34px;
+  --shadow-xs: 0 1px 2px rgba(16, 24, 40, 0.04);
+  --shadow-sm: 0 1px 3px rgba(16, 24, 40, 0.08), 0 1px 2px rgba(16, 24, 40, 0.04);
+  --shadow-lg: 0 12px 32px rgba(16, 24, 40, 0.1);
 }
 
 /* ===================== Admin console ===================== */
@@ -278,11 +294,10 @@
 .admin-skeleton { display: grid; gap: 10px; }
 .skeleton-row {
   height: 64px; border-radius: 10px;
-  background: linear-gradient(90deg, var(--color-code-bg) 25%, var(--color-border) 37%, var(--color-code-bg) 63%);
-  background-size: 400% 100%;
-  animation: admin-shimmer 1.4s ease infinite;
+  background: var(--color-hover);
+  animation: admin-pulse 1.4s ease-in-out infinite;
 }
-@keyframes admin-shimmer { 0% { background-position: 100% 0; } 100% { background-position: 0 0; } }
+@keyframes admin-pulse { 0%, 100% { opacity: 0.65; } 50% { opacity: 1; } }
 
 /* Toast */
 .admin-toast {
@@ -308,22 +323,33 @@
 
 [data-theme="dark"] {
   --color-bg: #0d1117;
-  --color-text: #e6edf3;
-  --color-text-secondary: #8b949e;
-  --color-border: #30363d;
-  --color-link: #58a6ff;
-  --color-link-hover: #79c0ff;
-  --color-code-bg: #161b22;
+  --color-panel: #111219;
+  --color-sidebar: #0d0e13;
+  --color-text: #e8eaf0;
+  --color-text-secondary: #9298a4;
+  --color-text-faint: #646a76;
+  --color-border: #1d1f27;
+  --color-border-strong: #262933;
+  --color-hover: #181a22;
+  --color-link: #a6a4f7;
+  --color-link-hover: #c3c1fb;
+  --color-code-bg: #07080c;
+  --color-code-text: #e6e8ef;
   --color-code-border: #30363d;
-  --color-blockquote-border: #30363d;
-  --color-blockquote-text: #8b949e;
-  --color-header-bg: #161b22;
-  --color-tag-bg: #1f3044;
-  --color-tag-text: #58a6ff;
-  --color-table-border: #30363d;
-  --color-table-row-alt: #161b22;
+  --color-blockquote-border: #2a2d45;
+  --color-blockquote-text: #9298a4;
+  --color-header-bg: rgba(17, 18, 25, 0.82);
+  --color-tag-bg: #191b2b;
+  --color-tag-text: #7c7ff2;
+  --color-table-border: #262933;
+  --color-table-row-alt: #13151c;
   --color-success: #3fb950;
   --color-danger: #f85149;
+  --color-accent: #7c7ff2;
+  --color-accent-hover: #9698f5;
+  --color-accent-soft: #191b2b;
+  --color-accent-line: #2a2d45;
+  --shadow-lg: 0 12px 34px rgba(0, 0, 0, 0.5);
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -336,79 +362,154 @@ body {
   background: var(--color-bg);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  transition: background 0.25s ease, color 0.25s ease;
 }
+
+svg { display: block; }
+.i { width: 18px; height: 18px; stroke-width: 1.75; }
 
 /* Header */
 .page-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 24px;
+  min-height: 56px;
+  padding: 0 16px 0 14px;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-header-bg);
+  backdrop-filter: saturate(180%) blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 800;
 }
 
 .breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
   font-size: 14px;
   color: var(--color-text-secondary);
 }
 
 .breadcrumb a {
-  color: var(--color-link);
+  color: var(--color-text-secondary);
   text-decoration: none;
 }
 
-.breadcrumb a:hover { text-decoration: underline; }
+.breadcrumb a:hover { color: var(--color-text); }
 
 .breadcrumb .sep {
-  margin: 0 6px;
-  color: var(--color-text-secondary);
+  color: var(--color-text-faint);
 }
 
 .breadcrumb-folder {
   color: var(--color-text-secondary);
 }
 
-.theme-toggle {
-  background: none;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 4px 10px;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  font-size: 14px;
+.breadcrumb .current {
+  color: var(--color-text);
+  font-weight: 550;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.theme-toggle:hover { background: var(--color-code-bg); }
+.btn,
+.icon-btn {
+  font-family: inherit;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease;
+  white-space: nowrap;
+}
 
-.theme-icon::before { content: "🌙"; }
-[data-theme="dark"] .theme-icon::before { content: "☀️"; }
+.btn {
+  height: var(--control-height);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1;
+}
+
+.btn .i {
+  width: 16px;
+  height: 16px;
+}
+
+.icon-btn {
+  width: var(--control-height);
+  height: var(--control-height);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+}
+
+.icon-btn:hover {
+  background: var(--color-hover);
+  color: var(--color-text);
+}
+
+.btn-secondary {
+  background: var(--color-panel);
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-xs);
+}
+
+.btn-secondary:hover {
+  background: var(--color-hover);
+}
+
+.btn-primary {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-xs);
+}
+
+.btn-primary:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+.theme-icon {
+  display: none;
+}
+
+:root:not([data-theme="dark"]) .theme-icon-moon,
+[data-theme="dark"] .theme-icon-sun {
+  display: inline-flex;
+}
 
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
+}
+
+.header-actions .share-btn {
+  margin-left: 6px;
 }
 
 .logout-form { margin: 0; }
 
 .logout-btn {
-  background: none;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 4px 10px;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  font-size: 13px;
+  appearance: none;
 }
-
-.logout-btn:hover { background: var(--color-code-bg); color: var(--color-text); }
 
 /* Layout */
 .page-layout {
   max-width: calc(var(--content-width) + 48px);
   margin: 0 auto;
-  padding: 32px 24px;
+  padding: 34px 24px;
 }
 
 .page-layout.has-toc {
@@ -423,21 +524,8 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
-
-/* Nav toggle button (hamburger) */
-.nav-toggle {
-  background: none;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 4px 8px;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  display: flex;
-  align-items: center;
-}
-
-.nav-toggle:hover { background: var(--color-code-bg); color: var(--color-text); }
 
 /* Nav sidebar — fixed drawer from left edge */
 .nav-sidebar {
@@ -446,11 +534,11 @@ body {
   left: 0;
   bottom: 0;
   width: var(--nav-width);
-  background: var(--color-bg);
+  background: var(--color-sidebar);
   border-right: 1px solid var(--color-border);
   z-index: 900;
   overflow-y: auto;
-  padding: 16px;
+  padding: 14px 10px;
   transform: translateX(-100%);
   transition: transform 0.2s ease;
 }
@@ -469,12 +557,43 @@ body {
 
 .nav-overlay[hidden] { display: none; }
 
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 4px 8px 14px;
+}
+
+.nav-brand-mark {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  border-radius: 7px;
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.nav-brand-mark .i {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2;
+}
+
+.nav-brand b {
+  font-size: 15px;
+  font-weight: 650;
+}
+
 .page-nav h4 {
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--color-text-secondary);
-  margin-bottom: 8px;
+  letter-spacing: 0.07em;
+  color: var(--color-text-faint);
+  margin: 0;
+  padding: 10px 10px 5px;
 }
 
 .page-nav ul {
@@ -485,28 +604,42 @@ body {
 .page-nav li { margin: 2px 0; }
 
 .page-nav-list > .nav-folder {
-  margin: 6px 0;
+  margin: 4px 0;
 }
 
 .nav-folder summary {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  min-height: var(--control-height);
   gap: 8px;
-  padding: 4px 8px;
+  padding: 0 10px;
   cursor: pointer;
   color: var(--color-text-secondary);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
-  border-radius: 4px;
+  border-radius: var(--radius);
+  list-style: none;
+}
+
+.nav-folder summary::-webkit-details-marker {
+  display: none;
+}
+
+.nav-folder summary .i,
+.page-nav a .i {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  opacity: 0.85;
 }
 
 .nav-folder summary:hover {
-  background: var(--color-code-bg);
+  background: var(--color-hover);
   color: var(--color-text);
 }
 
 .nav-folder-name {
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -514,8 +647,9 @@ body {
 
 .nav-folder-count {
   flex-shrink: 0;
-  color: var(--color-text-secondary);
+  color: var(--color-text-faint);
   font-weight: 400;
+  font-size: 12px;
 }
 
 .nav-folder-list {
@@ -525,26 +659,37 @@ body {
 }
 
 .page-nav a {
-  display: block;
-  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: var(--control-height);
+  padding: 0 10px;
   font-size: 13px;
   color: var(--color-text-secondary);
   text-decoration: none;
-  border-radius: 4px;
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.page-nav a:hover {
+  color: var(--color-text);
+  background: var(--color-hover);
+}
+
+.page-nav a span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.page-nav a:hover {
-  color: var(--color-link);
-  background: var(--color-code-bg);
+.page-nav li.active a {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  font-weight: 550;
 }
 
-.page-nav li.active a {
-  color: var(--color-link);
-  background: var(--color-tag-bg);
-  font-weight: 500;
+.page-nav li.active a .i {
+  opacity: 1;
 }
 
 /* TOC sidebar */
@@ -559,7 +704,7 @@ body {
 
 .toc {
   font-size: 13px;
-  border-left: 2px solid var(--color-border);
+  border-left: 1px solid var(--color-border);
   padding-left: 12px;
 }
 
@@ -591,7 +736,7 @@ body {
 
 /* HTML artifact iframe container */
 .html-artifact-container {
-  height: calc(100vh - 57px);
+  height: calc(100vh - 56px);
   overflow: hidden;
 }
 
@@ -618,9 +763,9 @@ body {
 }
 
 .page-title {
-  font-size: 2em;
-  font-weight: 600;
-  line-height: 1.25;
+  font-size: 32px;
+  font-weight: 750;
+  line-height: 1.22;
   margin-bottom: 8px;
 }
 
@@ -632,18 +777,21 @@ body {
   display: inline-block;
   background: var(--color-tag-bg);
   color: var(--color-tag-text);
-  padding: 2px 8px;
-  border-radius: 12px;
+  border: 1px solid var(--color-accent-line);
+  padding: 2px 9px;
+  border-radius: 999px;
   font-size: 12px;
   margin-right: 4px;
 }
 
 /* Markdown body */
 .markdown-body {
-  font-size: 16px;
-  line-height: 1.7;
+  font-size: 15.5px;
+  line-height: 1.75;
   word-wrap: break-word;
 }
+
+.markdown-body > *:first-child { margin-top: 0; }
 
 .markdown-body h1,
 .markdown-body h2,
@@ -651,57 +799,81 @@ body {
 .markdown-body h4,
 .markdown-body h5,
 .markdown-body h6 {
-  margin-top: 1.5em;
-  margin-bottom: 0.5em;
-  font-weight: 600;
+  margin-top: 1.7em;
+  margin-bottom: 0.55em;
+  font-weight: 680;
   line-height: 1.25;
 }
 
-.markdown-body h1 { font-size: 2em; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3em; }
-.markdown-body h2 { font-size: 1.5em; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3em; }
-.markdown-body h3 { font-size: 1.25em; }
-.markdown-body h4 { font-size: 1em; }
+.markdown-body h1 {
+  font-size: 30px;
+  font-weight: 750;
+  letter-spacing: 0;
+  line-height: 1.22;
+}
 
-.markdown-body p { margin: 0 0 1em; }
+.markdown-body h2 {
+  font-size: 22px;
+  letter-spacing: 0;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--color-border);
+}
 
-.markdown-body a { color: var(--color-link); text-decoration: none; }
-.markdown-body a:hover { text-decoration: underline; }
+.markdown-body h3 { font-size: 18px; font-weight: 650; }
+.markdown-body h4 { font-size: 16px; }
+
+.markdown-body p { margin: 0 0 1.1em; }
+
+.markdown-body a {
+  color: var(--color-link);
+  text-decoration: none;
+  font-weight: 500;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-link) 30%, transparent);
+}
+
+.markdown-body a:hover { border-bottom-color: var(--color-link); }
 
 .markdown-body img {
   max-width: 100%;
   height: auto;
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
 }
 
 .markdown-body blockquote {
-  border-left: 4px solid var(--color-blockquote-border);
-  padding: 0.5em 1em;
-  margin: 0 0 1em;
+  border-left: 3px solid var(--color-blockquote-border);
+  padding: 0.3em 1.1em;
+  margin: 1.4em 0;
   color: var(--color-blockquote-text);
+  font-style: normal;
 }
 
 .markdown-body code {
   font-family: var(--font-mono);
   font-size: 85%;
-  background: var(--color-code-bg);
-  border: 1px solid var(--color-code-border);
-  border-radius: 4px;
-  padding: 0.2em 0.4em;
+  background: var(--color-hover);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 5px;
+  padding: 0.12em 0.38em;
 }
 
 .markdown-body pre {
   background: var(--color-code-bg);
   border: 1px solid var(--color-code-border);
-  border-radius: 6px;
-  padding: 16px;
+  border-radius: var(--radius-lg);
+  color: var(--color-code-text);
+  padding: 15px 16px;
   overflow-x: auto;
-  margin: 0 0 1em;
-  line-height: 1.45;
+  margin: 1.4em 0;
+  line-height: 1.7;
+  box-shadow: var(--shadow-xs);
 }
 
 .markdown-body pre code {
   background: none;
   border: none;
+  color: inherit;
   padding: 0;
   font-size: 85%;
 }
@@ -714,26 +886,54 @@ body {
 }
 
 .markdown-body .shiki {
-  border-radius: 6px;
-  padding: 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-code-border);
+  padding: 15px 16px;
   overflow-x: auto;
-  margin: 0 0 1em;
+  margin: 1.4em 0;
+  box-shadow: var(--shadow-xs);
 }
 
 .markdown-body ul,
 .markdown-body ol {
-  padding-left: 2em;
-  margin: 0 0 1em;
+  padding-left: 1.35em;
+  margin: 0 0 1.1em;
 }
 
-.markdown-body li { margin: 0.25em 0; }
+.markdown-body li { margin: 0.35em 0; }
+
+.markdown-body ul li::marker { color: var(--color-accent); }
+
+.markdown-body ol li::marker {
+  color: var(--color-text-faint);
+  font-weight: 600;
+}
 
 .markdown-body li > p { margin: 0.5em 0; }
+
+.markdown-body kbd {
+  font-family: var(--font-mono);
+  font-size: 78%;
+  background: var(--color-panel);
+  border: 1px solid var(--color-border-strong);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  padding: 0.1em 0.4em;
+}
+
+.markdown-body mark {
+  background: #fff3a3;
+  color: #181a20;
+  border-radius: 4px;
+  padding: 0.05em 0.2em;
+}
 
 .markdown-body .table-wrapper {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  margin: 0 0 1em;
+  margin: 1.4em 0;
+  border: 1px solid var(--color-table-border);
+  border-radius: var(--radius-lg);
 }
 
 .markdown-body table {
@@ -743,25 +943,29 @@ body {
 
 .markdown-body th,
 .markdown-body td {
-  border: 1px solid var(--color-table-border);
-  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-table-border);
+  padding: 10px 14px;
   text-align: left;
   white-space: nowrap;
 }
 
 .markdown-body th {
   font-weight: 600;
-  background: var(--color-header-bg);
+  background: var(--color-hover);
 }
 
 .markdown-body tr:nth-child(even) {
   background: var(--color-table-row-alt);
 }
 
+.markdown-body tr:last-child td {
+  border-bottom: 0;
+}
+
 .markdown-body hr {
   border: none;
-  border-top: 1px solid var(--color-border);
-  margin: 1.5em 0;
+  border-top: 1px solid var(--color-border-strong);
+  margin: 2.2em 0;
 }
 
 .markdown-body input[type="checkbox"] {
@@ -925,13 +1129,13 @@ body {
     margin-top: 2px;
   }
   .theme-toggle {
-    min-width: 44px;
-    min-height: 44px;
+    width: 44px;
+    height: 44px;
     display: flex;
     align-items: center;
     justify-content: center;
   }
-  .page-title { font-size: 1.5em; }
+  .page-title { font-size: 24px; }
   .markdown-body { font-size: 15px; }
   .markdown-body pre,
   .markdown-body .shiki {
@@ -948,24 +1152,6 @@ body {
 /* Share viewer — hide auth-only elements */
 [data-viewer="share"] .auth-only { display: none !important; }
 
-/* Header action buttons */
-.share-btn,
-.copy-raw-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  background: none;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 4px 10px;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  font-size: 13px;
-}
-
-.share-btn:hover,
-.copy-raw-btn:hover { background: var(--color-code-bg); color: var(--color-link); }
-
 .share-btn:disabled,
 .copy-raw-btn:disabled {
   cursor: default;
@@ -977,10 +1163,9 @@ body {
 
 @media (max-width: 768px) {
   .copy-raw-btn {
-    min-width: 44px;
-    min-height: 44px;
+    height: 44px;
     justify-content: center;
-    padding: 4px 8px;
+    padding: 0 10px;
   }
 
   .copy-raw-label { display: none; }

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,4 +1,5 @@
 import { browserBaseFromRequest } from '../lib/browser-base.js';
+import { themeToggleIcons } from '../templates/icons.js';
 
 const ASSET_VERSION = Date.now();
 
@@ -20,7 +21,9 @@ export function adminRoute() {
   <header class="page-header">
     <nav class="breadcrumb"><a href="${baseUrl}/">Pages</a></nav>
     <div class="header-actions">
-      <button class="theme-toggle" aria-label="Toggle dark mode"><span class="theme-icon"></span></button>
+      <button class="theme-toggle icon-btn" aria-label="Toggle dark mode">
+        ${themeToggleIcons()}
+      </button>
       <form method="POST" action="${baseUrl}/logout" class="logout-form"><button type="submit" class="logout-btn" aria-label="Sign out">Sign out</button></form>
     </div>
   </header>

--- a/src/templates/icons.js
+++ b/src/templates/icons.js
@@ -1,0 +1,19 @@
+const ICONS = {
+  sidebar: '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/>',
+  copy: '<rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
+  share: '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4"/>',
+  moon: '<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>',
+  sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>',
+  logout: '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/>',
+  document: '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v5h5"/>',
+  folder: '<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"/>',
+};
+
+export function icon(name, className = 'i') {
+  return `<svg class="${className}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${ICONS[name]}</svg>`;
+}
+
+export function themeToggleIcons() {
+  return `<span class="theme-icon theme-icon-moon">${icon('moon')}</span>
+        <span class="theme-icon theme-icon-sun">${icon('sun')}</span>`;
+}

--- a/src/templates/pageTemplate.js
+++ b/src/templates/pageTemplate.js
@@ -6,6 +6,21 @@ import { buildPageTree } from '../utils/pageTree.js';
 // Stable cache version — generated once per process start
 const ASSET_VERSION = Date.now();
 
+const ICONS = {
+  sidebar: '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/>',
+  copy: '<rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
+  share: '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4"/>',
+  moon: '<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>',
+  sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>',
+  logout: '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/>',
+  document: '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v5h5"/>',
+  folder: '<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"/>',
+};
+
+function icon(name, className = 'i') {
+  return `<svg class="${className}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${ICONS[name]}</svg>`;
+}
+
 /**
  * Generate a complete HTML page from rendered content.
  * The HTML is cached per slug — viewer-specific adjustments (share vs auth)
@@ -35,25 +50,26 @@ export function pageTemplate({ title, description, date, tags, bodyHtml, tocItem
 <body>
   <header class="page-header">
     <div class="header-left">
-      <button class="nav-toggle auth-only" aria-label="Toggle pages list">
-        <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor"><path d="M2 4h14v1.5H2zm0 4.25h14v1.5H2zm0 4.25h14v1.5H2z"/></svg>
+      <button class="nav-toggle icon-btn auth-only" aria-label="Toggle pages list">
+        ${icon('sidebar')}
       </button>
       ${renderBreadcrumb({ baseUrl, slug, title })}
     </div>
     <div class="header-actions">
-      <button class="copy-raw-btn auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Copy raw Markdown">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M5 1.5A1.5 1.5 0 0 1 6.5 0h6A1.5 1.5 0 0 1 14 1.5v8A1.5 1.5 0 0 1 12.5 11h-6A1.5 1.5 0 0 1 5 9.5zm1.5-.25a.25.25 0 0 0-.25.25v8c0 .138.112.25.25.25h6a.25.25 0 0 0 .25-.25v-8a.25.25 0 0 0-.25-.25zM2 4.5A1.5 1.5 0 0 1 3.5 3H4v1.25h-.5a.25.25 0 0 0-.25.25v8c0 .138.112.25.25.25h6a.25.25 0 0 0 .25-.25V12H11v.5A1.5 1.5 0 0 1 9.5 14h-6A1.5 1.5 0 0 1 2 12.5z"/></svg>
+      <button class="copy-raw-btn btn btn-secondary auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Copy raw Markdown">
+        ${icon('copy')}
         <span class="copy-raw-label">Copy Markdown</span>
       </button>
-      <button class="share-btn auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Share this page">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.5 2.5 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5z"/></svg>
+      <button class="share-btn btn btn-primary auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Share this page">
+        ${icon('share')}
         Share
       </button>
-      <button class="theme-toggle" aria-label="Toggle dark mode">
-        <span class="theme-icon"></span>
+      <button class="theme-toggle icon-btn" aria-label="Toggle dark mode">
+        <span class="theme-icon theme-icon-moon">${icon('moon')}</span>
+        <span class="theme-icon theme-icon-sun">${icon('sun')}</span>
       </button>
       <form method="POST" action="${baseUrl}/logout" class="logout-form auth-only">
-        <button type="submit" class="logout-btn" aria-label="Sign out">Sign out</button>
+        <button type="submit" class="logout-btn icon-btn" aria-label="Sign out" title="Sign out">${icon('logout')}</button>
       </form>
     </div>
   </header>
@@ -141,21 +157,22 @@ export function htmlArtifactTemplate({ title, baseUrl, slug, iframeSrc }) {
 <body class="html-artifact-page">
   <header class="page-header">
     <div class="header-left">
-      <button class="nav-toggle auth-only" aria-label="Toggle pages list">
-        <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor"><path d="M2 4h14v1.5H2zm0 4.25h14v1.5H2zm0 4.25h14v1.5H2z"/></svg>
+      <button class="nav-toggle icon-btn auth-only" aria-label="Toggle pages list">
+        ${icon('sidebar')}
       </button>
       ${renderBreadcrumb({ baseUrl, slug, title })}
     </div>
     <div class="header-actions">
-      <button class="share-btn auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Share this page">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.5 2.5 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5z"/></svg>
+      <button class="share-btn btn btn-primary auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Share this page">
+        ${icon('share')}
         Share
       </button>
-      <button class="theme-toggle" aria-label="Toggle dark mode">
-        <span class="theme-icon"></span>
+      <button class="theme-toggle icon-btn" aria-label="Toggle dark mode">
+        <span class="theme-icon theme-icon-moon">${icon('moon')}</span>
+        <span class="theme-icon theme-icon-sun">${icon('sun')}</span>
       </button>
       <form method="POST" action="${baseUrl}/logout" class="logout-form auth-only">
-        <button type="submit" class="logout-btn" aria-label="Sign out">Sign out</button>
+        <button type="submit" class="logout-btn icon-btn" aria-label="Sign out" title="Sign out">${icon('logout')}</button>
       </form>
     </div>
   </header>
@@ -229,14 +246,16 @@ export function injectNavSidebar(html, pages, currentSlug, baseUrl) {
 
 function renderNavSidebar(pages, currentSlug, baseUrl) {
   const pageTree = buildPageTree(pages);
-  let html = '<aside class="nav-sidebar auth-only"><nav class="page-nav"><h4>Pages</h4><ul class="page-nav-list">';
+  let html = `<aside class="nav-sidebar auth-only"><nav class="page-nav">
+    <div class="nav-brand"><span class="nav-brand-mark">${icon('document')}</span><b>Pages</b></div>
+    <h4>Workspace</h4><ul class="page-nav-list">`;
   for (const page of pageTree.topLevel) {
     html += renderNavPageItem(page, currentSlug, baseUrl);
   }
 
   for (const folder of pageTree.folders) {
-    const isOpen = folder.pages.some(page => page.slug === currentSlug);
-    html += `<li class="nav-folder"><details${isOpen ? ' open' : ''}><summary><span class="nav-folder-name">${escapeHtml(folder.label)}</span><span class="nav-folder-count">${folder.pages.length}</span></summary><ul class="nav-folder-list">`;
+    const isOpen = folder.pages.some(page => isCurrentPageSlug(page.slug, currentSlug));
+    html += `<li class="nav-folder"><details${isOpen ? ' open' : ''}><summary>${icon('folder')}<span class="nav-folder-name">${escapeHtml(folder.label)}</span><span class="nav-folder-count">${folder.pages.length}</span></summary><ul class="nav-folder-list">`;
     for (const page of folder.pages) {
       html += renderNavPageItem(page, currentSlug, baseUrl);
     }
@@ -248,8 +267,12 @@ function renderNavSidebar(pages, currentSlug, baseUrl) {
 }
 
 function renderNavPageItem(page, currentSlug, baseUrl) {
-  const active = page.slug === currentSlug ? ' class="active"' : '';
-  return `<li${active}><a href="${baseUrl}/${encodeURI(page.slug)}">${escapeHtml(page.title)}</a></li>`;
+  const active = isCurrentPageSlug(page.slug, currentSlug) ? ' class="active"' : '';
+  return `<li${active}><a href="${baseUrl}/${encodeURI(page.slug)}">${icon('document')}<span>${escapeHtml(page.title)}</span></a></li>`;
+}
+
+function isCurrentPageSlug(pageSlug, currentSlug) {
+  return pageSlug === currentSlug || pageSlug === `p/${currentSlug}` || `p/${pageSlug}` === currentSlug;
 }
 
 function renderBreadcrumb({ baseUrl, slug, title }) {

--- a/src/templates/pageTemplate.js
+++ b/src/templates/pageTemplate.js
@@ -2,24 +2,10 @@
 
 import { escapeHtml } from '../security/sanitize.js';
 import { buildPageTree } from '../utils/pageTree.js';
+import { icon, themeToggleIcons } from './icons.js';
 
 // Stable cache version — generated once per process start
 const ASSET_VERSION = Date.now();
-
-const ICONS = {
-  sidebar: '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/>',
-  copy: '<rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
-  share: '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4"/>',
-  moon: '<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>',
-  sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>',
-  logout: '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/>',
-  document: '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v5h5"/>',
-  folder: '<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"/>',
-};
-
-function icon(name, className = 'i') {
-  return `<svg class="${className}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${ICONS[name]}</svg>`;
-}
 
 /**
  * Generate a complete HTML page from rendered content.
@@ -65,8 +51,7 @@ export function pageTemplate({ title, description, date, tags, bodyHtml, tocItem
         Share
       </button>
       <button class="theme-toggle icon-btn" aria-label="Toggle dark mode">
-        <span class="theme-icon theme-icon-moon">${icon('moon')}</span>
-        <span class="theme-icon theme-icon-sun">${icon('sun')}</span>
+        ${themeToggleIcons()}
       </button>
       <form method="POST" action="${baseUrl}/logout" class="logout-form auth-only">
         <button type="submit" class="logout-btn icon-btn" aria-label="Sign out" title="Sign out">${icon('logout')}</button>
@@ -168,8 +153,7 @@ export function htmlArtifactTemplate({ title, baseUrl, slug, iframeSrc }) {
         Share
       </button>
       <button class="theme-toggle icon-btn" aria-label="Toggle dark mode">
-        <span class="theme-icon theme-icon-moon">${icon('moon')}</span>
-        <span class="theme-icon theme-icon-sun">${icon('sun')}</span>
+        ${themeToggleIcons()}
       </button>
       <form method="POST" action="${baseUrl}/logout" class="logout-form auth-only">
         <button type="submit" class="logout-btn icon-btn" aria-label="Sign out" title="Sign out">${icon('logout')}</button>

--- a/test/page-tree.test.js
+++ b/test/page-tree.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -87,10 +87,40 @@ test('injectNavSidebar expands active folder and escapes folder labels', () => {
     { slug: 'safe/<script>/page', title: 'Unsafe Folder', date: '2026-06-12' },
   ], 'daily-digest/a', '/pages');
 
-  assert.match(html, /<details open><summary><span class="nav-folder-name">daily-digest<\/span>/);
-  assert.match(html, /<li class="active"><a href="\/pages\/daily-digest\/a">Daily A<\/a><\/li>/);
+  assert.match(html, /<details open><summary><svg class="i"[^>]*stroke="currentColor"[^>]*><path d="M3 7/);
+  assert.match(html, /<span class="nav-folder-name">daily-digest<\/span>/);
+  assert.match(html, /<li class="active"><a href="\/pages\/daily-digest\/a"><svg class="i"[^>]*stroke="currentColor"[^>]*><path d="M15 2/);
+  assert.match(html, /<span>Daily A<\/span><\/a><\/li>/);
   assert.match(html, /safe \/ &lt;script&gt;/);
   assert.doesNotMatch(html, /<span class="nav-folder-name">safe \/ <script>/);
+});
+
+test('injectNavSidebar highlights p-prefixed logical pages for canonical routes', () => {
+  const html = injectNavSidebar('<html><body><!-- NAV_SIDEBAR --></body></html>', [
+    { slug: 'p/visual', title: 'Visual', date: '2026-07-01' },
+  ], 'visual', '/pages');
+
+  assert.match(html, /<li class="active"><a href="\/pages\/p\/visual">/);
+});
+
+test('viewer chrome uses inline SVG icons and no emoji theme fallback', async () => {
+  const html = pageTemplate({
+    title: 'Icons',
+    description: '',
+    date: '',
+    tags: [],
+    bodyHtml: '<p>Body</p>',
+    tocItems: [],
+    baseUrl: '/pages',
+    slug: 'icons',
+  });
+  const css = await readFile(new URL('../assets/style.css', import.meta.url), 'utf8');
+
+  assert.match(html, /<button class="theme-toggle icon-btn" aria-label="Toggle dark mode">/);
+  assert.match(html, /<span class="theme-icon theme-icon-moon"><svg class="i"[^>]*stroke="currentColor"/);
+  assert.match(html, /<span class="theme-icon theme-icon-sun"><svg class="i"[^>]*stroke="currentColor"/);
+  const legacyThemeIconPattern = new RegExp('\\u{1f319}|\\u{2600}\\u{fe0f}|theme-icon' + '::before', 'u');
+  assert.doesNotMatch(css, legacyThemeIconPattern);
 });
 
 test('injectShareViewer marks share pages and exposes attachment edit flag', () => {

--- a/test/page-tree.test.js
+++ b/test/page-tree.test.js
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { scanPages } from '../src/pages/navigation.js';
+import { adminRoute } from '../src/routes/admin.js';
 import { injectNavSidebar, injectShareViewer, pageTemplate } from '../src/templates/pageTemplate.js';
 import { buildPageTree } from '../src/utils/pageTree.js';
 
@@ -121,6 +122,30 @@ test('viewer chrome uses inline SVG icons and no emoji theme fallback', async ()
   assert.match(html, /<span class="theme-icon theme-icon-sun"><svg class="i"[^>]*stroke="currentColor"/);
   const legacyThemeIconPattern = new RegExp('\\u{1f319}|\\u{2600}\\u{fe0f}|theme-icon' + '::before', 'u');
   assert.doesNotMatch(css, legacyThemeIconPattern);
+});
+
+test('admin chrome uses inline SVG theme icons', () => {
+  let html = '';
+  const handler = adminRoute();
+  handler({
+    protocol: 'http',
+    headers: {},
+    get() {
+      return 'example.test';
+    },
+    originalUrl: '/',
+    baseUrl: '',
+  }, {
+    setHeader() {},
+    send(body) {
+      html = body;
+    },
+  });
+
+  assert.match(html, /<button class="theme-toggle icon-btn" aria-label="Toggle dark mode">/);
+  assert.match(html, /<span class="theme-icon theme-icon-moon"><svg class="i"[^>]*stroke="currentColor"/);
+  assert.match(html, /<span class="theme-icon theme-icon-sun"><svg class="i"[^>]*stroke="currentColor"/);
+  assert.doesNotMatch(html, /<span class="theme-icon"><\/span>/);
 });
 
 test('injectShareViewer marks share pages and exposes attachment edit flag', () => {


### PR DESCRIPTION
## Summary
- Replace viewer/header/sidebar iconography with one Lucide-style inline SVG set and unified 34px button controls
- Refresh Pages viewer tokens, sticky glass header, drawer/sidebar styling, active state, and Markdown prose/table/code styling for light and dark themes
- Add tests covering SVG icon chrome, no emoji theme fallback, and p-prefixed nav active state

## Validation
- npm test
- npm test -- test/page-tree.test.js test/html-artifacts.test.js
- npm run build:admin
- rg scan for emoji theme fallbacks, fill="currentColor", and linear-gradient in viewer sources
- Manual Chrome headless screenshots: light, dark, and sidebar active state