### PR TITLE
Complete Pages viewer UI polish

### DIFF
--- a/assets/codeblocks.js
+++ b/assets/codeblocks.js
@@ -1,0 +1,64 @@
+// Code block copy controls.
+
+(function () {
+  'use strict';
+
+  var buttons = document.querySelectorAll('.code-copy-btn');
+  if (!buttons.length) return;
+
+  function copyText(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    return new Promise(function (resolve, reject) {
+      var textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.top = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+
+      try {
+        var copied = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        copied ? resolve() : reject(new Error('copy failed'));
+      } catch (err) {
+        document.body.removeChild(textarea);
+        reject(err);
+      }
+    });
+  }
+
+  buttons.forEach(function (button) {
+    var defaultText = button.textContent;
+    var resetTimer = null;
+
+    button.addEventListener('click', function () {
+      var block = button.closest('.code-block');
+      var code = block && block.querySelector('pre code');
+      if (!code) return;
+
+      button.disabled = true;
+      button.textContent = 'Copying...';
+
+      copyText(code.textContent)
+        .then(function () {
+          button.textContent = 'Copied';
+          button.classList.add('is-copied');
+        })
+        .catch(function () {
+          button.textContent = 'Failed';
+        })
+        .finally(function () {
+          clearTimeout(resetTimer);
+          resetTimer = setTimeout(function () {
+            button.disabled = false;
+            button.textContent = defaultText;
+            button.classList.remove('is-copied');
+          }, 1600);
+        });
+    });
+  });
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -24,6 +24,8 @@
   --color-table-row-alt: #fbfbfc;
   --color-success: #1a7f37;
   --color-danger: #cf222e;
+  --color-warning: #9a6700;
+  --color-info: #0969da;
   --color-accent: #6366f1;
   --color-accent-hover: #4f46e5;
   --color-accent-soft: #eef0fe;
@@ -345,6 +347,8 @@
   --color-table-row-alt: #13151c;
   --color-success: #3fb950;
   --color-danger: #f85149;
+  --color-warning: #d29922;
+  --color-info: #58a6ff;
   --color-accent: #7c7ff2;
   --color-accent-hover: #9698f5;
   --color-accent-soft: #191b2b;
@@ -373,6 +377,7 @@ svg { display: block; }
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
   min-height: 56px;
   padding: 0 16px 0 14px;
   border-bottom: 1px solid var(--color-border);
@@ -388,11 +393,14 @@ svg { display: block; }
   align-items: center;
   gap: 8px;
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   font-size: 14px;
   color: var(--color-text-secondary);
 }
 
 .breadcrumb a {
+  flex-shrink: 0;
   color: var(--color-text-secondary);
   text-decoration: none;
 }
@@ -400,10 +408,15 @@ svg { display: block; }
 .breadcrumb a:hover { color: var(--color-text); }
 
 .breadcrumb .sep {
+  flex-shrink: 0;
   color: var(--color-text-faint);
 }
 
 .breadcrumb-folder {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--color-text-secondary);
 }
 
@@ -493,6 +506,7 @@ svg { display: block; }
   display: flex;
   align-items: center;
   gap: 4px;
+  flex-shrink: 0;
 }
 
 .header-actions .share-btn {
@@ -525,6 +539,7 @@ svg { display: block; }
   align-items: center;
   gap: 8px;
   min-width: 0;
+  flex: 1;
 }
 
 /* Nav sidebar — fixed drawer from left edge */
@@ -848,6 +863,63 @@ svg { display: block; }
   font-style: normal;
 }
 
+.markdown-body .callout {
+  display: grid;
+  gap: 8px;
+  margin: 1.4em 0;
+  padding: 12px 14px;
+  border: 1px solid var(--callout-border);
+  border-left-width: 4px;
+  border-radius: var(--radius);
+  background: var(--callout-bg);
+  color: var(--color-text);
+}
+
+.markdown-body .callout-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 650;
+  line-height: 1.3;
+  color: var(--callout-accent);
+}
+
+.markdown-body .callout-title .i {
+  flex: none;
+  width: 17px;
+  height: 17px;
+  stroke-width: 2;
+}
+
+.markdown-body .callout-body > *:last-child,
+.markdown-body .callout-body:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .callout-info {
+  --callout-accent: var(--color-info);
+  --callout-border: color-mix(in srgb, var(--color-info) 34%, var(--color-border));
+  --callout-bg: color-mix(in srgb, var(--color-info) 8%, transparent);
+}
+
+.markdown-body .callout-tip {
+  --callout-accent: var(--color-accent);
+  --callout-border: color-mix(in srgb, var(--color-accent) 34%, var(--color-border));
+  --callout-bg: color-mix(in srgb, var(--color-accent) 8%, transparent);
+}
+
+.markdown-body .callout-warn {
+  --callout-accent: var(--color-warning);
+  --callout-border: color-mix(in srgb, var(--color-warning) 38%, var(--color-border));
+  --callout-bg: color-mix(in srgb, var(--color-warning) 10%, transparent);
+}
+
+.markdown-body .callout-ok {
+  --callout-accent: var(--color-success);
+  --callout-border: color-mix(in srgb, var(--color-success) 34%, var(--color-border));
+  --callout-bg: color-mix(in srgb, var(--color-success) 8%, transparent);
+}
+
 .markdown-body code {
   font-family: var(--font-mono);
   font-size: 85%;
@@ -868,6 +940,77 @@ svg { display: block; }
   margin: 1.4em 0;
   line-height: 1.7;
   box-shadow: var(--shadow-xs);
+}
+
+.markdown-body .code-block {
+  margin: 1.4em 0;
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-code-bg);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+}
+
+.markdown-body .code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 36px;
+  padding: 0 10px 0 13px;
+  border-bottom: 1px solid var(--color-code-border);
+  background: color-mix(in srgb, var(--color-code-bg) 88%, var(--color-panel));
+}
+
+.markdown-body .code-block-language {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1;
+  color: var(--color-text-faint);
+}
+
+.markdown-body .code-copy-btn {
+  min-width: 58px;
+  height: 26px;
+  padding: 0 9px;
+  border: 1px solid var(--color-code-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease;
+}
+
+.markdown-body .code-copy-btn:hover:not(:disabled) {
+  background: var(--color-hover);
+  color: var(--color-text);
+}
+
+.markdown-body .code-copy-btn:disabled {
+  cursor: default;
+  opacity: 0.85;
+}
+
+.markdown-body .code-copy-btn.is-copied {
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 42%, var(--color-code-border));
+}
+
+.markdown-body .code-block > pre,
+.markdown-body .code-block .shiki {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .markdown-body pre code {
@@ -1142,10 +1285,60 @@ svg { display: block; }
     padding: 12px;
     font-size: 13px;
   }
+  .markdown-body .code-block > pre,
+  .markdown-body .code-block .shiki {
+    padding: 12px;
+  }
   .markdown-body th,
   .markdown-body td {
     padding: 6px 10px;
     font-size: 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .page-header {
+    padding: 8px 10px;
+    gap: 8px;
+  }
+
+  .header-left {
+    gap: 6px;
+  }
+
+  .breadcrumb {
+    gap: 5px;
+  }
+
+  .breadcrumb-folder,
+  .breadcrumb a,
+  .breadcrumb .sep {
+    display: none;
+  }
+
+  .breadcrumb .current {
+    max-width: 100%;
+  }
+
+  .header-actions {
+    gap: 2px;
+  }
+
+  .header-actions .share-btn {
+    width: 44px;
+    height: 44px;
+    margin-left: 0;
+    padding: 0;
+  }
+
+  .header-actions .share-btn .i {
+    width: 18px;
+    height: 18px;
+  }
+
+  .header-actions .share-btn {
+    font-size: 0;
+    gap: 0;
   }
 }
 

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,5 +1,5 @@
 import { browserBaseFromRequest } from '../lib/browser-base.js';
-import { themeToggleIcons } from '../templates/icons.js';
+import { icon, themeToggleIcons } from '../templates/icons.js';
 
 const ASSET_VERSION = Date.now();
 
@@ -24,7 +24,7 @@ export function adminRoute() {
       <button class="theme-toggle icon-btn" aria-label="Toggle dark mode">
         ${themeToggleIcons()}
       </button>
-      <form method="POST" action="${baseUrl}/logout" class="logout-form"><button type="submit" class="logout-btn" aria-label="Sign out">Sign out</button></form>
+      <form method="POST" action="${baseUrl}/logout" class="logout-form"><button type="submit" class="logout-btn icon-btn" aria-label="Sign out" title="Sign out">${icon('logout')}</button></form>
     </div>
   </header>
   <main class="admin-page">

--- a/src/services/renderWorker.js
+++ b/src/services/renderWorker.js
@@ -11,6 +11,82 @@ import { postProcessMermaid } from '../markdown/mermaid.js';
 
 const { filePath, config } = workerData;
 
+const CALLOUTS = {
+  NOTE: {
+    tone: 'info',
+    label: 'Note',
+    icon: '<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>',
+  },
+  TIP: {
+    tone: 'tip',
+    label: 'Tip',
+    icon: '<path d="M15 14c.2-1 .7-1.7 1.5-2.5a5 5 0 1 0-7 0c.8.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/>',
+  },
+  WARNING: {
+    tone: 'warn',
+    label: 'Warning',
+    icon: '<path d="m21.7 18-8.5-15a1.4 1.4 0 0 0-2.4 0L2.3 18a1.4 1.4 0 0 0 1.2 2h17a1.4 1.4 0 0 0 1.2-2Z"/><path d="M12 9v4"/><path d="M12 17h.01"/>',
+  },
+  CAUTION: {
+    tone: 'warn',
+    label: 'Warning',
+    icon: '<path d="m21.7 18-8.5-15a1.4 1.4 0 0 0-2.4 0L2.3 18a1.4 1.4 0 0 0 1.2 2h17a1.4 1.4 0 0 0 1.2-2Z"/><path d="M12 9v4"/><path d="M12 17h.01"/>',
+  },
+  IMPORTANT: {
+    tone: 'warn',
+    label: 'Important',
+    icon: '<path d="M12 9v4"/><path d="M12 17h.01"/><path d="M5 7.2A8 8 0 0 1 12 3a8 8 0 0 1 7 4.2c.7 1.2.7 2.7 0 3.9L12 21 5 11.1a3.8 3.8 0 0 1 0-3.9Z"/>',
+  },
+  OK: {
+    tone: 'ok',
+    label: 'OK',
+    icon: '<path d="M20 6 9 17l-5-5"/>',
+  },
+  SUCCESS: {
+    tone: 'ok',
+    label: 'Success',
+    icon: '<path d="M20 6 9 17l-5-5"/>',
+  },
+};
+
+function escapeAttr(value) {
+  return String(value).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+function humanizeLanguage(lang) {
+  if (!lang) return 'Text';
+  const aliases = { javascript: 'JavaScript', js: 'JavaScript', jsx: 'JSX', typescript: 'TypeScript', ts: 'TypeScript', tsx: 'TSX', py: 'Python', sh: 'Shell', bash: 'Bash', yml: 'YAML', md: 'Markdown' };
+  return aliases[lang] || lang.charAt(0).toUpperCase() + lang.slice(1);
+}
+
+function codeBlockChrome(attrs, body) {
+  const classMatch = attrs.match(/class="[^"]*\blanguage-([^"\s]+)[^"]*"/);
+  const lang = classMatch ? classMatch[1].toLowerCase() : 'text';
+  const label = humanizeLanguage(lang);
+  return `<div class="code-block" data-language="${escapeAttr(lang)}"><div class="code-block-header"><span class="code-block-language">${escapeAttr(label)}</span><button type="button" class="code-copy-btn" aria-label="Copy ${escapeAttr(label)} code">Copy</button></div>${body}</div>`;
+}
+
+function enhanceCodeBlocks(html) {
+  html = html.replace(/<pre><code([^>]*)>(<pre class="shiki[\s\S]*?<\/pre>)\s*<\/code><\/pre>/g, (_full, attrs, shikiPre) => {
+    return codeBlockChrome(attrs, shikiPre);
+  });
+
+  return html.replace(/<pre><code([^>]*)>([\s\S]*?)<\/code><\/pre>/g, (full, attrs, inner) => {
+    if (/class="mermaid"/.test(full)) return full;
+    return codeBlockChrome(attrs, `<pre><code${attrs}>${inner}</code></pre>`);
+  });
+}
+
+function enhanceCallouts(html) {
+  return html.replace(/<blockquote>\s*<p>\[!(NOTE|TIP|WARNING|CAUTION|IMPORTANT|OK|SUCCESS)\](?:<br\s*\/?>|\n)([\s\S]*?)<\/p>\s*<\/blockquote>/gi, (_full, type, content) => {
+    const spec = CALLOUTS[type.toUpperCase()];
+    if (!spec) return _full;
+    return `<aside class="callout callout-${spec.tone}"><div class="callout-title"><svg class="i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${spec.icon}</svg><span>${spec.label}</span></div><div class="callout-body">${content}</div></aside>`;
+  });
+}
+
 async function render() {
   const { readFile, stat } = await import('node:fs/promises');
   const { createHash } = await import('node:crypto');
@@ -105,6 +181,8 @@ async function render() {
       allowedSchemes: ['http', 'https', 'mailto'],
     });
   }
+
+  bodyHtml = enhanceCallouts(enhanceCodeBlocks(bodyHtml));
 
   // Strip leading H1 only if its text matches the frontmatter title (avoid duplicate)
   if (meta.title) {

--- a/src/templates/pageTemplate.js
+++ b/src/templates/pageTemplate.js
@@ -114,6 +114,7 @@ export function pageTemplate({ title, description, date, tags, bodyHtml, tocItem
   </div>
   <script src="${baseUrl}/_assets/share.js?v=${ASSET_VERSION}"></script>
   <script src="${baseUrl}/_assets/nav.js?v=${ASSET_VERSION}"></script>
+  <script src="${baseUrl}/_assets/codeblocks.js?v=${ASSET_VERSION}"></script>
   ${bodyHtml.includes('class="mermaid"') ? `<script src="${baseUrl}/_assets/mermaid.min.js?v=${ASSET_VERSION}"></script>
   <script src="${baseUrl}/_assets/mermaid-zoom.js?v=${ASSET_VERSION}"></script>
   <script src="${baseUrl}/_assets/mermaid-init.js?v=${ASSET_VERSION}"></script>` : ''}

--- a/test/asset-route.test.js
+++ b/test/asset-route.test.js
@@ -229,7 +229,11 @@ test('root route serves admin console and /admin is not mounted', async () => {
     try {
       const root = await fetch(`${origin}/`);
       assert.equal(root.status, 200);
-      assert.match(await root.text(), /id="pages-admin-root"/);
+      const rootHtml = await root.text();
+      assert.match(rootHtml, /id="pages-admin-root"/);
+      assert.match(rootHtml, /class="logout-btn icon-btn"/);
+      assert.match(rootHtml, /aria-label="Sign out"/);
+      assert.doesNotMatch(rootHtml, />Sign out<\/button>/);
 
       const oldAdmin = await fetch(`${origin}/admin`, { redirect: 'manual' });
       assert.equal(oldAdmin.status, 404);

--- a/test/markdown-ui.test.js
+++ b/test/markdown-ui.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { renderPage } from '../src/services/renderService.js';
+
+test('markdown renderer adds code block headers, copy controls, and callout tones', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'zylos-pages-markdown-ui-'));
+  try {
+    const sourcePath = path.join(dir, 'ui.md');
+    await writeFile(sourcePath, [
+      '# UI',
+      '',
+      '> [!NOTE]',
+      '> Keep this visible.',
+      '',
+      '> [!TIP]',
+      '> Use the button.',
+      '',
+      '> [!WARNING]',
+      '> Check the result.',
+      '',
+      '> [!OK]',
+      '> Completed.',
+      '',
+      '```javascript',
+      'const value = 1;',
+      '```',
+      '',
+      '```mermaid',
+      'graph TD',
+      '```',
+    ].join('\n'));
+
+    const rendered = await renderPage(sourcePath, {
+      baseUrl: '/pages',
+      slug: 'ui',
+      renderTimeoutMs: 10_000,
+    });
+
+    assert.match(rendered.html, /class="code-block" data-language="javascript"/);
+    assert.match(rendered.html, /class="code-block-language">JavaScript<\/span>/);
+    assert.match(rendered.html, /class="code-copy-btn" aria-label="Copy JavaScript code">Copy<\/button>/);
+    assert.match(rendered.html, /src="\/pages\/_assets\/codeblocks\.js\?v=/);
+    assert.match(rendered.html, /class="callout callout-info"/);
+    assert.match(rendered.html, /class="callout callout-tip"/);
+    assert.match(rendered.html, /class="callout callout-warn"/);
+    assert.match(rendered.html, /class="callout callout-ok"/);
+    assert.match(rendered.html, /<pre class="mermaid">graph TD\s*<\/pre>/);
+    assert.doesNotMatch(rendered.html, /data-language="mermaid"/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('viewer CSS protects narrow sticky header and styles code/callout UI', async () => {
+  const css = await readFile(new URL('../assets/style.css', import.meta.url), 'utf8');
+
+  assert.match(css, /@media \(max-width: 480px\)/);
+  assert.match(css, /\.breadcrumb-folder,\s*\.breadcrumb a,\s*\.breadcrumb \.sep\s*\{\s*display: none;/);
+  assert.match(css, /\.header-actions\s*\{[\s\S]*?flex-shrink: 0;/);
+  assert.match(css, /\.header-left\s*\{[\s\S]*?flex: 1;/);
+  assert.match(css, /\.markdown-body \.code-block-header/);
+  assert.match(css, /\.markdown-body \.code-copy-btn\.is-copied/);
+  assert.match(css, /\.markdown-body \.callout-info/);
+  assert.match(css, /\.markdown-body \.callout-tip/);
+  assert.match(css, /\.markdown-body \.callout-warn/);
+  assert.match(css, /\.markdown-body \.callout-ok/);
+});
+
+test('code block copy script exposes copied feedback', async () => {
+  const script = await readFile(new URL('../assets/codeblocks.js', import.meta.url), 'utf8');
+
+  assert.match(script, /querySelectorAll\('\.code-copy-btn'\)/);
+  assert.match(script, /button\.textContent = 'Copied'/);
+  assert.match(script, /button\.classList\.add\('is-copied'\)/);
+  assert.match(script, /navigator\.clipboard\.writeText/);
+});


### PR DESCRIPTION
## Summary
- Add fenced code block chrome with language labels, copy buttons, and copied/failed feedback.
- Add GitHub-style callout rendering for info, tip, warning, and ok/success tones using inline SVG icons.
- Tighten sticky header responsiveness at narrow widths and convert the admin sign-out control to the viewer icon-button style.

## Validation
- `node --test test/markdown-ui.test.js`
- `node --test test/asset-route.test.js`
- `npm test`
- `npm run build:admin`
- `git diff --check`
- Playwright/Chrome screenshots for desktop and 375px mobile in light and dark: `/tmp/zylos-pages-ui-shots/desktop-light.png`, `/tmp/zylos-pages-ui-shots/desktop-dark.png`, `/tmp/zylos-pages-ui-shots/mobile-light.png`, `/tmp/zylos-pages-ui-shots/mobile-dark.png`

## Notes
- No route, auth, share, or auth-only hiding behavior changes.
- Mermaid fences remain excluded from the code-copy wrapper.