### PR TITLE
Align mobile header action sizing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1324,9 +1324,28 @@ svg { display: block; }
     gap: 2px;
   }
 
+  .header-actions .copy-raw-btn,
+  .header-actions .theme-toggle,
+  .header-actions .logout-btn {
+    width: var(--control-height);
+    height: var(--control-height);
+    padding: 0;
+    border-color: transparent;
+    background: transparent;
+    box-shadow: none;
+    color: var(--color-text-secondary);
+  }
+
+  .header-actions .copy-raw-btn:hover:not(:disabled),
+  .header-actions .theme-toggle:hover,
+  .header-actions .logout-btn:hover {
+    background: var(--color-hover);
+    color: var(--color-text);
+  }
+
   .header-actions .share-btn {
-    width: 44px;
-    height: 44px;
+    width: var(--control-height);
+    height: var(--control-height);
     margin-left: 0;
     padding: 0;
   }

--- a/test/markdown-ui.test.js
+++ b/test/markdown-ui.test.js
@@ -62,6 +62,8 @@ test('viewer CSS protects narrow sticky header and styles code/callout UI', asyn
   assert.match(css, /\.breadcrumb-folder,\s*\.breadcrumb a,\s*\.breadcrumb \.sep\s*\{\s*display: none;/);
   assert.match(css, /\.header-actions\s*\{[\s\S]*?flex-shrink: 0;/);
   assert.match(css, /\.header-left\s*\{[\s\S]*?flex: 1;/);
+  assert.match(css, /\.header-actions \.copy-raw-btn,\s*\.header-actions \.theme-toggle,\s*\.header-actions \.logout-btn\s*\{[\s\S]*?width: var\(--control-height\);[\s\S]*?height: var\(--control-height\);[\s\S]*?border-color: transparent;[\s\S]*?background: transparent;/);
+  assert.match(css, /\.header-actions \.share-btn\s*\{[\s\S]*?width: var\(--control-height\);[\s\S]*?height: var\(--control-height\);/);
   assert.match(css, /\.markdown-body \.code-block-header/);
   assert.match(css, /\.markdown-body \.code-copy-btn\.is-copied/);
   assert.match(css, /\.markdown-body \.callout-info/);


### PR DESCRIPTION
## Summary
- make Copy, theme, and logout ghost icon buttons at 34x34 on <=480px viewports
- keep Share as the only solid primary action while sizing it to 34x34 on narrow screens
- add CSS coverage for the narrow header action sizing rules

## Validation
- node --test test/markdown-ui.test.js
- npm run build:admin
- npm test
- git diff --check
- 375x812 light/dark Playwright visual check: Copy/theme/logout measured 34x34 transparent ghost buttons, Share measured 34x34 solid primary, scrollWidth stayed 375