### PR TITLE
Package A: console color cleanup + back-to-console entry

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -10,6 +10,7 @@
   --color-border: #ededf0;
   --color-border-strong: #e3e4e8;
   --color-hover: #f4f4f6;
+  --color-hover-bg: #f0f1f4;
   --color-link: #5b57e8;
   --color-link-hover: #4f46e5;
   --color-code-bg: #1a1c23;
@@ -20,6 +21,8 @@
   --color-header-bg: rgba(255, 255, 255, 0.82);
   --color-tag-bg: #eef0fe;
   --color-tag-text: #6366f1;
+  --color-status-bg: #f1f2f4;
+  --color-status-text: #5f6673;
   --color-table-border: #e3e4e8;
   --color-table-row-alt: #fbfbfc;
   --color-success: #1a7f37;
@@ -71,7 +74,7 @@
   flex-shrink: 0;
   font-size: 0.8rem;
   color: var(--color-text-secondary);
-  background: var(--color-code-bg);
+  background: transparent;
   border: 1px solid var(--color-border);
   border-radius: 999px;
   padding: 5px 12px;
@@ -121,9 +124,9 @@
 .btn-primary { background: var(--color-link); color: #fff; }
 .btn-primary:hover:not(:disabled) { background: var(--color-link-hover); }
 .btn-secondary { background: var(--color-bg); color: var(--color-text); border-color: var(--color-border); }
-.btn-secondary:hover:not(:disabled) { background: var(--color-code-bg); }
+.btn-secondary:hover:not(:disabled) { background: var(--color-hover-bg); }
 .btn-ghost { background: transparent; color: var(--color-text-secondary); border-color: transparent; }
-.btn-ghost:hover:not(:disabled) { background: var(--color-code-bg); color: var(--color-text); }
+.btn-ghost:hover:not(:disabled) { background: var(--color-hover-bg); color: var(--color-text); }
 .copy-btn.is-copied { color: var(--color-success); }
 
 /* Form */
@@ -210,7 +213,7 @@
   color: var(--color-text-secondary); font-size: 1.1rem; line-height: 1;
   padding: 2px 6px; border-radius: 6px;
 }
-.search-clear:hover { background: var(--color-code-bg); color: var(--color-text); }
+.search-clear:hover { background: var(--color-hover-bg); color: var(--color-text); }
 
 /* Page list */
 .admin-list { display: grid; gap: 10px; }
@@ -252,7 +255,7 @@
   font-size: 0.72rem; font-weight: 600; line-height: 1.4;
 }
 .badge-neutral { background: var(--color-tag-bg); color: var(--color-tag-text); }
-.badge-private { background: var(--color-code-bg); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
+.badge-private { background: var(--color-status-bg); color: var(--color-status-text); border: 1px solid var(--color-border); }
 .badge-shared { background: rgba(31, 136, 61, 0.12); color: var(--color-success); }
 
 /* Share control */
@@ -287,7 +290,7 @@
 .empty-icon {
   width: 44px; height: 44px; border-radius: 12px;
   display: flex; align-items: center; justify-content: center;
-  background: var(--color-code-bg); color: var(--color-text-secondary);
+  background: var(--color-hover-bg); color: var(--color-text-secondary);
   margin-bottom: 6px;
 }
 .empty-icon .i { width: 22px; height: 22px; }
@@ -333,6 +336,7 @@
   --color-border: #1d1f27;
   --color-border-strong: #262933;
   --color-hover: #181a22;
+  --color-hover-bg: #20222b;
   --color-link: #a6a4f7;
   --color-link-hover: #c3c1fb;
   --color-code-bg: #07080c;
@@ -343,6 +347,8 @@
   --color-header-bg: rgba(17, 18, 25, 0.82);
   --color-tag-bg: #191b2b;
   --color-tag-text: #7c7ff2;
+  --color-status-bg: #22242c;
+  --color-status-text: #b6bcc9;
   --color-table-border: #262933;
   --color-table-row-alt: #13151c;
   --color-success: #3fb950;
@@ -1190,7 +1196,7 @@ svg { display: block; }
 }
 
 .page-folder summary:hover {
-  background: var(--color-code-bg);
+  background: var(--color-hover-bg);
 }
 
 .page-folder-name {
@@ -1534,7 +1540,7 @@ svg { display: block; }
   white-space: nowrap;
 }
 
-.share-copy-btn:hover { background: var(--color-code-bg); }
+.share-copy-btn:hover { background: var(--color-hover-bg); }
 
 .share-item-copy-btn {
   padding: 3px 8px;

--- a/src/templates/icons.js
+++ b/src/templates/icons.js
@@ -7,6 +7,7 @@ const ICONS = {
   logout: '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/>',
   document: '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v5h5"/>',
   folder: '<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"/>',
+  grid: '<rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/>',
 };
 
 export function icon(name, className = 'i') {

--- a/src/templates/pageTemplate.js
+++ b/src/templates/pageTemplate.js
@@ -42,6 +42,9 @@ export function pageTemplate({ title, description, date, tags, bodyHtml, tocItem
       ${renderBreadcrumb({ baseUrl, slug, title })}
     </div>
     <div class="header-actions">
+      <a class="console-link icon-btn auth-only" href="${baseUrl}/" aria-label="Back to console" title="Back to console">
+        ${icon('grid')}
+      </a>
       <button class="copy-raw-btn btn btn-secondary auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Copy raw Markdown">
         ${icon('copy')}
         <span class="copy-raw-label">Copy Markdown</span>
@@ -149,6 +152,9 @@ export function htmlArtifactTemplate({ title, baseUrl, slug, iframeSrc }) {
       ${renderBreadcrumb({ baseUrl, slug, title })}
     </div>
     <div class="header-actions">
+      <a class="console-link icon-btn auth-only" href="${baseUrl}/" aria-label="Back to console" title="Back to console">
+        ${icon('grid')}
+      </a>
       <button class="share-btn btn btn-primary auth-only" data-slug="${escapeHtml(slug || '')}" data-base-url="${escapeHtml(baseUrl)}" aria-label="Share this page">
         ${icon('share')}
         Share


### PR DESCRIPTION
Owner-requested UI feedback (batch, package A of 2).

**Changes**
1. **Back to console** — logged-in doc viewer top bar gets a `grid` icon button (left-most in `.header-actions`, in both authed header blocks) linking to the console root `${baseUrl}/`. Carries `.auth-only`, so share-token viewers do not see it.
2. **Kill the near-black "black-gray" pills** — root cause was `--color-code-bg` (#1a1c23, meant for code blocks) reused as a UI surface:
   - `.admin-count` counter → transparent outlined chip
   - `.badge-private` → neutral `--color-status-bg` (distinct from the indigo category tags), light+dark tokens
   - interactive hover-to-near-black neutralized via new `--color-hover-bg` (`.btn-secondary`/`.btn-ghost`/`.search-clear`/`.share-copy-btn` hover, `.empty-icon`, `.page-folder summary:hover`)
   - real code-block / inline-code surfaces left dark on purpose

Only indigo remains as the single accent color.

**Verification**: 112/112 tests green; headless screenshots at desktop + 375px, light + dark, incl. a hover-state capture proving the Share button no longer goes near-black; no horizontal overflow; share viewer confirmed to hide the new button.

Package B (Feishu-style tree doc management) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)