### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,29 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.0] - 2026-07-02
 
 ### Added
-- **Local DB agent CLI for Pages registration/sharing**: `src/cli/pages.js` now provides one agent-facing CLI for `register`, `list`, `share`, `shares`, `unshare`, and `allow-root add`, with JSON output and compatibility forwarding from `external-files.js`. Registration continues to use the shared `registerLogicalPage()` four-gate validation path, and `allow-root add` preserves existing config fields while extending `externalFiles.allowedSources`.
+- **Feishu-style document management console** (#95): the authenticated console's page-card grid is replaced by a folder tree + row list derived purely from `uri` path prefixes. Supports drag-to-move (native HTML5 DnD, changes the uri prefix), inline title rename (title only, decoupled from uri), and client-side New folder (materializes when a document is dropped in; empty folders are not persisted). The Register page button and dialog are removed — registration is CLI-only via `pages.js register`.
+- **Local DB agent CLI for Pages registration/sharing** (#77, #78): `src/cli/pages.js` provides one agent-facing CLI for `register`, `list`, `share`, `shares`, `unshare`, and `allow-root add`, with JSON output and compatibility forwarding from `external-files.js`. Registration uses the shared `registerLogicalPage()` four-gate validation path; the share URL base is configurable (`config.publicBaseUrl`).
+- **`PATCH /api/pages/:pageId`** (#95): admin-authenticated move (uri change, uniqueness-checked) and rename (title change) endpoint; the pages list API now returns `pageId`.
+- **Back to console** icon button on the authenticated doc viewer top bar (#94) — hidden on share pages and for unauthenticated visitors.
+- **Copy-link actions** for active shares in the console (#80) and in the page share dialog (#88).
+- **Viewer markdown upgrades** (#92): fenced code blocks get a header bar with language label + copy button; four-tone callouts (`> [!NOTE]`-style info / tip / warn / ok) with Lucide SVG icons.
 
 ### Changed
-- **Pages console registration is tucked behind a top-bar action**: the authenticated console now presents the page list/search as the primary view, removes Admin branding, and opens the path-based registration form only from the Register page button with private-by-default wording.
+- **BREAKING — stable `page_id` primary key** (#95): `logical_pages` is rebuilt around an internal `page_id` (uuid) primary key with `uri` demoted to a mutable unique column; `shares`/`share_sessions` are re-keyed from slug to `page_id`, so **share links survive page moves and renames**. A one-time idempotent startup migration backfills uuids; **legacy slug-keyed share rows are dropped** (not convertible) and the legacy `shares.json` import is removed. Source files on disk never move — move/rename only updates DB state.
+- **Viewer UI modernization** (#91, #92, #93): left navigation sidebar + top toolbar redesign on the doc viewer, sticky glass header with responsive narrow-screen (375px) convergence, and a unified 34×34 icon-button family across viewer and admin (theme / logout / copy actions).
+- **Console recolor** (#94): near-black pills and hover states (a `--color-code-bg` leak into UI surfaces) replaced with new `--color-status-bg` / `--color-hover-bg` tokens; the console now uses a single indigo accent.
+- **Sidebar navigation sources from the logical page registry** (#79) instead of scanning the filesystem.
+
+### Fixed
+- Owner direct views resolve shared assets (#76).
+- Share asset signature slug normalization — fixes share-image 403s from the `p/` prefix mismatch (#89).
+
+### Security
+- **Auth fails closed when no password is configured** (#82).
+- **Page serving and asset resolution are restricted to registered pages** (#83, #84).
+- **Legacy `?token=` share tokens deprecated and the bypass removed** (#86, #90); legacy pages routes cleaned up (#81).
 
 ## [0.6.0] - 2026-06-30
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.6.0
+version: 0.7.0
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## What

Version bump + CHANGELOG for the v0.7.0 release, closing out the release freeze that began after the 0.6.0 bump (#74; its tag was deleted under the merge-only release model).

- `package.json`, `package-lock.json` (both locations), `SKILL.md` frontmatter → 0.7.0
- CHANGELOG `[0.7.0] - 2026-07-02` entry consolidating the former `[Unreleased]` section plus all 18 merges since the 0.6.0 bump (#76–#95): agent CLI, the 8-wave legacy-route/behavior audit, viewer UI modernization, Package A console recolor, and Package B (Feishu-style doc tree + page_id primary key decoupling, breaking share migration).

No code changes — live is already running main (`a47be7d`). After merge: tag `v0.7.0` + GitHub Release + registry sync.

## Test plan
- 119/119 `npm test` on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)