### PR TITLE
Add logical page unregister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.1] - 2026-07-02
+
+### Added
+- **Logical page unregister** (#97): `src/cli/pages.js unregister <uri> [--json]` removes the logical page registration and returns `page_missing` for absent pages.
+- **`DELETE /api/pages/:pageId`** (#97): owner-authenticated endpoint reuses the same unregister service path for admin deletion.
+
+### Changed
+- Unregister/delete removes `share_sessions` and `shares` rows directly by stable `page_id` in the same transaction as the `logical_pages` delete, leaving the source file on disk untouched.
+
 ## [0.7.0] - 2026-07-02
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.7.0
+version: 0.7.1
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.
@@ -62,6 +62,10 @@ node $PAGES_DIR/src/cli/pages.js list
 node $PAGES_DIR/src/cli/pages.js share reports/q3 --duration 7d
 node $PAGES_DIR/src/cli/pages.js shares reports/q3
 node $PAGES_DIR/src/cli/pages.js unshare reports/q3
+
+# Remove a logical page registration and page-id keyed share/session rows.
+# The source file on disk is left untouched.
+node $PAGES_DIR/src/cli/pages.js unregister reports/q3
 
 # Add a local directory to the allowed source roots.
 node $PAGES_DIR/src/cli/pages.js allow-root add /absolute/reports --name reports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",

--- a/src/cli/pages.js
+++ b/src/cli/pages.js
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CONFIG_PATH, DATA_DIR, getConfig } from '../lib/config.js';
-import { getLogicalPage, registerLogicalPage, searchLogicalPages } from '../pages/page-store.js';
+import { getLogicalPage, registerLogicalPage, searchLogicalPages, unregisterLogicalPage } from '../pages/page-store.js';
 import { createShare, listSharesForSlug, revokeAllForSlug } from '../sharing/share-manager.js';
 import { normalizeSlug } from '../utils/slug.js';
 
@@ -29,6 +29,7 @@ Usage:
   node pages.js share <uri> [--duration 24h|7d|30d|permanent] [--json]
   node pages.js shares <uri> [--json]
   node pages.js unshare <uri> [--json]
+  node pages.js unregister <uri> [--json]
   node pages.js allow-root add <path> [--name <name>] [--json]
   node pages.js status [--json]
 
@@ -87,6 +88,7 @@ function humanize(result) {
     return result.shares.map(share => `${share.tokenId} ${share.expiresAt ? new Date(Number(share.expiresAt)).toISOString() : 'never'}`).join('\n') || 'no active shares';
   }
   if (result.command === 'unshare') return `revoked ${result.revoked} share(s) for ${result.uri}`;
+  if (result.command === 'unregister') return `unregistered ${result.uri}`;
   if (result.command === 'allow-root') return `allowed root ${result.name}: ${result.path}`;
   return JSON.stringify(result, null, 2);
 }
@@ -277,6 +279,27 @@ function commandUnshare(args) {
   output({ ok: true, command: 'unshare', uri, slug, revoked }, args.json);
 }
 
+function commandUnregister(args) {
+  const uri = normalizeUri(args._[0] || args.uri || args.slug);
+  try {
+    const result = unregisterLogicalPage(uri);
+    output({
+      ok: true,
+      command: 'unregister',
+      uri: result.page.uri,
+      pageId: result.page.pageId,
+      removedShares: result.removedShares,
+      removedSessions: result.removedSessions,
+      sourcePath: result.page.sourcePath,
+    }, args.json);
+  } catch (err) {
+    if (err?.code === 'page_missing') {
+      throw new CliError('page_missing', `logical page not found: ${uri}`);
+    }
+    throw err;
+  }
+}
+
 function commandAllowRoot(args) {
   const subcommand = args._[0];
   if (subcommand !== 'add') {
@@ -338,6 +361,8 @@ export function main(argv) {
       return commandShares(args);
     case 'unshare':
       return commandUnshare(args);
+    case 'unregister':
+      return commandUnregister(args);
     case 'allow-root':
       return commandAllowRoot(args);
     case undefined:

--- a/src/pages/page-store.js
+++ b/src/pages/page-store.js
@@ -237,6 +237,54 @@ export function getLogicalPageById(pageId) {
   return mapPageRecord(db.prepare('SELECT * FROM logical_pages WHERE page_id = ?').get(pageId));
 }
 
+function tableExists(name) {
+  return Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name));
+}
+
+function unregisterLogicalPageRecord(page) {
+  if (!page) {
+    throw Object.assign(new Error('Page not found'), { statusCode: 404, code: 'page_missing' });
+  }
+  initPageStore();
+  const remove = db.transaction(() => {
+    const removedSessions = tableExists('share_sessions')
+      ? db.prepare('DELETE FROM share_sessions WHERE page_id = ?').run(page.pageId).changes
+      : 0;
+    const removedShares = tableExists('shares')
+      ? db.prepare('DELETE FROM shares WHERE page_id = ?').run(page.pageId).changes
+      : 0;
+    const removedPages = db.prepare('DELETE FROM logical_pages WHERE page_id = ?').run(page.pageId).changes;
+    return { removedSessions, removedShares, removedPages };
+  });
+  const result = remove();
+  if (result.removedPages === 0) {
+    throw Object.assign(new Error('Page not found'), { statusCode: 404, code: 'page_missing' });
+  }
+  logger.info('logical page unregistered', {
+    pageId: page.pageId,
+    uri: page.uri,
+    removedShares: result.removedShares,
+    removedSessions: result.removedSessions,
+  });
+  return {
+    page,
+    removedShares: result.removedShares,
+    removedSessions: result.removedSessions,
+  };
+}
+
+export function unregisterLogicalPage(uri) {
+  initPageStore();
+  const normalizedUri = normalizeSlug(uri);
+  const page = getLogicalPage(normalizedUri);
+  return unregisterLogicalPageRecord(page);
+}
+
+export function unregisterLogicalPageById(pageId) {
+  initPageStore();
+  return unregisterLogicalPageRecord(getLogicalPageById(pageId));
+}
+
 function validatedUpdateUri(rawUri) {
   let normalized;
   try {

--- a/src/routes/page-api.js
+++ b/src/routes/page-api.js
@@ -1,4 +1,9 @@
-import { registerLogicalPage, searchLogicalPages, updateLogicalPage } from '../pages/page-store.js';
+import {
+  registerLogicalPage,
+  searchLogicalPages,
+  unregisterLogicalPageById,
+  updateLogicalPage,
+} from '../pages/page-store.js';
 import { browserBaseFromRequest, browserPath } from '../lib/browser-base.js';
 import { logger } from '../utils/logger.js';
 
@@ -117,5 +122,24 @@ export function setupPageApi(app, config) {
       res.status(status).json({ error: status === 500 ? 'Internal Server Error' : err.message, code: err.code });
     }
   });
-}
 
+  app.delete('/api/pages/:pageId', (req, res) => {
+    if (!csrfCheck(req, res)) return;
+    if (!requireOwner(res)) return;
+
+    try {
+      const result = unregisterLogicalPageById(req.params.pageId);
+      res.json({
+        ok: true,
+        pageId: result.page.pageId,
+        uri: result.page.uri,
+        removedShares: result.removedShares,
+        removedSessions: result.removedSessions,
+      });
+    } catch (err) {
+      const status = err.statusCode || 500;
+      logger.warn('page unregister failed', { pageId: req.params.pageId, status, err: err.message });
+      res.status(status).json({ error: status === 500 ? 'Internal Server Error' : err.message, code: err.code });
+    }
+  });
+}

--- a/test/external-files.test.js
+++ b/test/external-files.test.js
@@ -14,6 +14,7 @@ process.env.PAGES_DATA_DIR = sharedDataDir;
 const { getPage } = await import('../src/services/pageService.js');
 const { getCachedPage, initCache, invalidatePagesForSlug, setCachedPage } = await import('../src/cache/pageCache.js');
 const { resolveLogicalAsset } = await import('../src/pages/asset-resolver.js');
+const { getPagesDb } = await import('../src/db/pages-db.js');
 
 function makeEnv(home, extra = {}) {
   return {
@@ -143,6 +144,46 @@ test('unified pages CLI registers, shares, lists shares, and unshares logical pa
 
   const after = runPagesCli(fixture, ['shares', 'recruit/share-target', '--json']);
   assert.deepEqual(after.shares, []);
+});
+
+test('pages CLI unregister removes registry and page-id keyed share rows but keeps source file', () => {
+  const fixture = makeFixture();
+  const source = path.join(fixture.sourceRoot, 'obsolete.md');
+  fs.writeFileSync(source, '# Obsolete\n');
+
+  runPagesCli(fixture, [
+    'register',
+    '--component', 'recruit',
+    '--uri', 'recruit/obsolete',
+    '--source', source,
+    '--json',
+  ]);
+  const share = runPagesCli(fixture, ['share', 'recruit/obsolete', '--duration', '24h', '--json']);
+  const db = getPagesDb();
+  const page = db.prepare('SELECT page_id FROM logical_pages WHERE uri = ?').get('recruit/obsolete');
+  assert.ok(page?.page_id);
+  db.prepare(`
+    INSERT INTO share_sessions (token_hash, token_id, page_id, created_at, last_activity_at, expires_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run('dummy-hash', share.tokenId, page.page_id, Date.now(), Date.now(), Date.now() + 3600_000);
+
+  const unregistered = runPagesCli(fixture, ['unregister', 'recruit/obsolete', '--json']);
+  assert.equal(unregistered.ok, true);
+  assert.equal(unregistered.command, 'unregister');
+  assert.equal(unregistered.uri, 'recruit/obsolete');
+  assert.equal(unregistered.pageId, page.page_id);
+  assert.equal(unregistered.removedShares, 1);
+  assert.equal(unregistered.removedSessions, 1);
+  assert.equal(unregistered.sourcePath, fs.realpathSync(source));
+
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM logical_pages WHERE page_id = ?').get(page.page_id).count, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM shares WHERE page_id = ?').get(page.page_id).count, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM share_sessions WHERE page_id = ?').get(page.page_id).count, 0);
+  assert.equal(fs.existsSync(source), true);
+
+  const repeated = runPagesCli(fixture, ['unregister', 'recruit/obsolete', '--json'], { expectFailure: true });
+  assert.equal(repeated.code, 'page_missing');
+  assert.equal(repeated.error, 'logical page not found: recruit/obsolete');
 });
 
 test('pages CLI share base URL uses config when env is absent', () => {

--- a/test/page-patch.test.js
+++ b/test/page-patch.test.js
@@ -11,6 +11,7 @@ process.env.PAGES_DATA_DIR = tmpDir;
 const express = (await import('express')).default;
 const { setupPageApi } = await import('../src/routes/page-api.js');
 const { setupShareApi } = await import('../src/routes/share-api.js');
+const { getPagesDb } = await import('../src/db/pages-db.js');
 const { getLogicalPage, getLogicalPageById, registerLogicalPage } = await import('../src/pages/page-store.js');
 const { getActiveShare, listSharesForSlug } = await import('../src/sharing/share-manager.js');
 
@@ -58,6 +59,17 @@ function patchPage(origin, pageId, body) {
   });
 }
 
+function deletePage(origin, pageId, headers = {}) {
+  return fetch(`${origin}/api/pages/${pageId}`, {
+    method: 'DELETE',
+    headers: {
+      Origin: origin,
+      'X-Forwarded-Proto': 'http',
+      ...headers,
+    },
+  });
+}
+
 test('PATCH renames title without touching uri', async () => {
   const { server, origin, contentDir, config } = await makeServer();
   try {
@@ -102,6 +114,67 @@ test('PATCH returns 404 for unknown pageId', async () => {
     const response = await patchPage(origin, 'no-such-page-id', { title: 'X' });
     assert.equal(response.status, 404);
     assert.equal((await response.json()).error, 'Page not found');
+  } finally {
+    server.close();
+  }
+});
+
+test('DELETE unregisters a page, removes page-id keyed share rows, and keeps source file', async () => {
+  const { server, origin, contentDir, config } = await makeServer();
+  try {
+    const page = registerPage(config, contentDir, 'delete/me', 'Delete Me');
+    const sourcePath = getLogicalPageById(page.pageId).sourcePath;
+
+    const create = await fetch(`${origin}/api/share`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: origin,
+        'X-Forwarded-Proto': 'http',
+      },
+      body: JSON.stringify({ slug: 'p/delete/me', duration: '24h' }),
+    });
+    assert.equal(create.status, 200);
+    const share = await create.json();
+
+    const db = getPagesDb();
+    db.prepare(`
+      INSERT INTO share_sessions (token_hash, token_id, page_id, created_at, last_activity_at, expires_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run('api-delete-session', share.tokenId, page.pageId, Date.now(), Date.now(), Date.now() + 3600_000);
+
+    const response = await deletePage(origin, page.pageId);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.pageId, page.pageId);
+    assert.equal(body.uri, 'delete/me');
+    assert.equal(body.removedShares, 1);
+    assert.equal(body.removedSessions, 1);
+
+    assert.equal(getLogicalPage('delete/me'), null);
+    assert.equal(getLogicalPageById(page.pageId), null);
+    assert.equal(getActiveShare(share.tokenId), null);
+    assert.deepEqual(listSharesForSlug('delete/me'), []);
+    assert.equal(db.prepare('SELECT COUNT(*) AS count FROM shares WHERE page_id = ?').get(page.pageId).count, 0);
+    assert.equal(db.prepare('SELECT COUNT(*) AS count FROM share_sessions WHERE page_id = ?').get(page.pageId).count, 0);
+    assert.equal(fs.existsSync(sourcePath), true);
+  } finally {
+    server.close();
+  }
+});
+
+test('DELETE returns page_missing for unknown pageId and enforces CSRF', async () => {
+  const { server, origin, contentDir, config } = await makeServer();
+  try {
+    const missing = await deletePage(origin, 'missing-page-id');
+    assert.equal(missing.status, 404);
+    assert.deepEqual(await missing.json(), { error: 'Page not found', code: 'page_missing' });
+
+    const page = registerPage(config, contentDir, 'delete/csrf', 'CSRF');
+    const crossOrigin = await deletePage(origin, page.pageId, { Origin: 'https://evil.example' });
+    assert.equal(crossOrigin.status, 403);
+    assert.equal(getLogicalPageById(page.pageId).uri, 'delete/csrf');
   } finally {
     server.close();
   }


### PR DESCRIPTION
## Summary
- Add `node src/cli/pages.js unregister <uri> [--json]` for removing logical page registrations.
- Add owner-authenticated `DELETE /api/pages/:pageId` using the same unregister service path.
- Bump package and skill version to `0.7.1`, with changelog notes for #97.

## Behavior
- Missing pages return `page_missing` through both CLI and HTTP paths.
- Unregister/delete leaves the source file on disk untouched.
- The unregister transaction directly deletes `share_sessions` and `shares` by stable `page_id`, then deletes the `logical_pages` row. I chose direct row deletion instead of revoking first because the issue asks for dependent rows to be removed and `page_id` makes that deterministic in one transaction.

## Validation
- `git diff --check`
- `npm test -- test/external-files.test.js test/page-patch.test.js`
- `npm test`

## Suggested real-environment check
After deploy, register a disposable page, create a share, run `pages.js unregister <uri> --json`, and confirm the source file still exists while the page and share URL stop resolving.

Closes #97
