### PR TITLE
Console UI refinements: unified logo, version caption, calmer type, adaptive width

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -48,9 +48,9 @@
 
 /* ===================== Admin console ===================== */
 .admin-page {
-  max-width: 960px;
+  max-width: min(1200px, 100% - 48px);
   margin: 0 auto;
-  padding: 32px 24px 64px;
+  padding: 32px 0 64px;
 }
 
 .admin-heading {
@@ -230,7 +230,7 @@
 }
 .tree-caret.is-open { transform: rotate(90deg); }
 .tree-name {
-  font-weight: 550;
+  font-weight: 600;
   font-size: 0.9rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -254,7 +254,9 @@
   min-width: 0;
 }
 .tree-title {
-  font-weight: 550;
+  /* CJK titles look muddy at heavy weights in small sizes — hierarchy comes
+     from color depth (title dark, uri/time muted), not thickness. */
+  font-weight: 500;
   font-size: 0.9rem;
   color: var(--color-text);
   text-decoration: none;
@@ -383,7 +385,7 @@
 .admin-toast-close:hover { opacity: 1; }
 
 @media (max-width: 600px) {
-  .admin-page { padding: 20px 16px 48px; }
+  .admin-page { max-width: 100%; padding: 20px 16px 48px; }
   .admin-heading-actions { justify-content: flex-start; width: 100%; }
   .admin-modal { padding: 12px; align-items: start; }
   .admin-modal-panel { max-height: calc(100vh - 24px); }
@@ -676,6 +678,21 @@ svg { display: block; }
 .nav-brand b {
   font-size: 15px;
   font-weight: 650;
+}
+
+/* Brand in the console top bar — same mark + wordmark as the viewer sidebar */
+.header-brand {
+  padding: 4px 0;
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.header-version {
+  font-size: 12px;
+  line-height: 1;
+  color: var(--color-text-faint);
+  margin-top: 3px; /* optically align with the wordmark baseline */
+  white-space: nowrap;
 }
 
 .page-nav h4 {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,7 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { browserBaseFromRequest } from '../lib/browser-base.js';
 import { icon, themeToggleIcons } from '../templates/icons.js';
 
 const ASSET_VERSION = Date.now();
+
+// Read the component version from package.json at startup — never hardcoded in markup.
+const APP_VERSION = (() => {
+  try {
+    const pkgPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../package.json');
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version || '';
+  } catch {
+    return '';
+  }
+})();
 
 export function adminRoute() {
   return (req, res) => {
@@ -19,7 +32,9 @@ export function adminRoute() {
 </head>
 <body>
   <header class="page-header">
-    <nav class="breadcrumb"><a href="${baseUrl}/">Pages</a></nav>
+    <div class="header-left">
+      <a href="${baseUrl}/" class="nav-brand header-brand"><span class="nav-brand-mark">${icon('document')}</span><b>Pages</b></a>${APP_VERSION ? `<span class="header-version">v${APP_VERSION}</span>` : ''}
+    </div>
     <div class="header-actions">
       <button class="theme-toggle icon-btn" aria-label="Toggle dark mode">
         ${themeToggleIcons()}


### PR DESCRIPTION
## Scope (Issue ae819dbe, 4-point round from Howard's screenshots)

1. **Unified logo** — console top bar now uses the same indigo rounded mark + wordmark as the viewer sidebar (`nav-brand` markup, same `icon('document')` SVG), linked to console root.
2. **Version caption** — muted `v{version}` next to the logo, read once at server startup from `package.json` (never hardcoded; caption omitted if read fails).
3. **CJK bold cleanup** — doc row titles 550→500 (hierarchy via color depth instead of thickness), folder names 550→600.
4. **Adaptive width** — `.admin-page` container `960px` → `min(1200px, 100% - 48px)`; ≤600px keeps prior full-width + 16px padding.

## Notes

- Pure CSS + server-rendered shell change; `Admin.jsx` untouched (`assets/admin.js` byte-identical, so no built-asset diff).
- Based on `358c43a` (v0.7.1) — version caption picks it up dynamically.
- No route/data/auth changes; CSP unaffected (no inline scripts).

## Testing

- `node --test`: 122/122 pass, zero test edits.
- `npm run build:admin` clean.
- Screenshots (isolated instance, seeded CJK data): wide-1600 light/dark + mobile-375 verified — logo matches viewer sidebar, caption reads v0.7.1, CJK titles clean at 500, list spreads at 1600px, mobile unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)