### PR TITLE
Viewer sidebar version caption + system-first font stack

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -33,7 +33,10 @@
   --color-accent-hover: #4f46e5;
   --color-accent-soft: #eef0fe;
   --color-accent-line: #e0e2fb;
-  --font-body: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "PingFang SC", Helvetica, Arial, sans-serif;
+  /* System-first stack: each platform renders its native UI face (SF Pro +
+     PingFang on macOS, Segoe + YaHei on Windows) so mixed CJK/Latin runs share
+     the metrics the OS designed to pair. No webfont — zero load cost. */
+  --font-body: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", Helvetica, Arial, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
   --content-width: 800px;
   --toc-width: 220px;
@@ -444,6 +447,7 @@ body {
   background: var(--color-bg);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   transition: background 0.25s ease, color 0.25s ease;
 }
 

--- a/src/lib/app-version.js
+++ b/src/lib/app-version.js
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Read the component version from package.json at startup — never hardcoded in markup.
+export const APP_VERSION = (() => {
+  try {
+    const pkgPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../package.json');
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version || '';
+  } catch {
+    return '';
+  }
+})();

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,20 +1,8 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { APP_VERSION } from '../lib/app-version.js';
 import { browserBaseFromRequest } from '../lib/browser-base.js';
 import { icon, themeToggleIcons } from '../templates/icons.js';
 
 const ASSET_VERSION = Date.now();
-
-// Read the component version from package.json at startup — never hardcoded in markup.
-const APP_VERSION = (() => {
-  try {
-    const pkgPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../package.json');
-    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version || '';
-  } catch {
-    return '';
-  }
-})();
 
 export function adminRoute() {
   return (req, res) => {

--- a/src/templates/pageTemplate.js
+++ b/src/templates/pageTemplate.js
@@ -1,5 +1,6 @@
 // HTML page template with SEO meta, TOC, theme support, and sharing
 
+import { APP_VERSION } from '../lib/app-version.js';
 import { escapeHtml } from '../security/sanitize.js';
 import { buildPageTree } from '../utils/pageTree.js';
 import { icon, themeToggleIcons } from './icons.js';
@@ -238,7 +239,7 @@ export function injectNavSidebar(html, pages, currentSlug, baseUrl) {
 function renderNavSidebar(pages, currentSlug, baseUrl) {
   const pageTree = buildPageTree(pages);
   let html = `<aside class="nav-sidebar auth-only"><nav class="page-nav">
-    <div class="nav-brand"><span class="nav-brand-mark">${icon('document')}</span><b>Pages</b></div>
+    <div class="nav-brand"><span class="nav-brand-mark">${icon('document')}</span><b>Pages</b>${APP_VERSION ? `<span class="header-version">v${APP_VERSION}</span>` : ''}</div>
     <h4>Workspace</h4><ul class="page-nav-list">`;
   for (const page of pageTree.topLevel) {
     html += renderNavPageItem(page, currentSlug, baseUrl);


### PR DESCRIPTION
## Scope (Issue ae819dbe acceptance feedback from Howard)

1. **Viewer sidebar version caption** — the muted `v{version}` caption added to the console top bar in #99 now also appears next to the viewer sidebar brand. Version logic extracted to shared `src/lib/app-version.js` (read once at startup from `package.json`, caption omitted on read failure); `admin.js` now imports it instead of duplicating.
2. **System-first font stack** (Howard picked "tune system stack" over webfonts) — `--font-body` drops `Inter`/`SF Pro Text` (only applied when locally installed → machine-dependent rendering) in favor of `system-ui` first, and adds proper CJK fallbacks: `PingFang SC` → `Hiragino Sans GB` → `Microsoft YaHei` → `Noto Sans SC`. Fixes Windows CJK falling through to SimSun. Added `-moz-osx-font-smoothing: grayscale` alongside the existing webkit rule.

## Testing

- `node --test`: 122/122 pass.
- Isolated instance (temp data dir, port 3972, killed by exact PID): verified `v0.7.1` renders in both viewer sidebar and console header; new font stack served. Screenshots taken (viewer + console, 1600px light).

No route/data/auth changes; no inline scripts (CSP unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)