### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.2] - 2026-07-02
+
+### Changed
+- **Console UI refinements** (#99): console top bar now uses the same indigo mark + wordmark brand as the viewer sidebar, with a muted version caption read from `package.json` at startup; doc row titles drop to weight 500 (hierarchy via color depth) and folder names to 600 for cleaner CJK rendering; the admin container widens adaptively to `min(1200px, 100% - 48px)` while ≤600px keeps the prior full-width layout.
+- **Viewer sidebar version caption + system-first font stack** (#100): the viewer sidebar brand shows the same version caption, with the version read shared via `src/lib/app-version.js`; `--font-body` now leads with `system-ui` and adds a full CJK fallback chain (`PingFang SC` → `Hiragino Sans GB` → `Microsoft YaHei` → `Noto Sans SC`), dropping the machine-dependent `Inter` entry and fixing Windows CJK falling through to SimSun; adds `-moz-osx-font-smoothing: grayscale`.
+
 ## [0.7.1] - 2026-07-02
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.7.1
+version: 0.7.2
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Release PR for v0.7.2 (Issue 79654457, Howard's「ship新版本」after accepting the UI-refinement round).

- Version bumped in all three places: `package.json`, `package-lock.json` (root + `packages[""]`), `SKILL.md` frontmatter.
- `CHANGELOG.md` gains a `[0.7.2]` entry covering #99 (console UI refinements) and #100 (viewer sidebar version caption + system-first font stack) — everything merged since the v0.7.1 entry.
- No code changes; `node --test` 122/122.

After approval: squash-merge → tag `v0.7.2` → GitHub Release → registry sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)