### PR TITLE
Login session takes precedence over share-access cookie on /p/ routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.3] - 2026-07-02
+
+### Fixed
+- **Login session takes precedence over share-access cookies** (#102): the auth middleware now checks the login session before the share-access cookie bypass, so an authenticated user always gets the authenticated (shell) view on `/p/<uri>` even when the browser still carries a `__Host-share_access` cookie from a previously opened share link. Previously the share bypass ran first and misclassified logged-in owners as share visitors, serving the shell-less raw view. The share-access cookie remains the unauthenticated fallback and deliberately keeps matching `/p/` logical routes — share views carry `<base href=".../p/<uri>">`, so anchor/TOC navigation from a share depends on it.
+
 ## [0.7.2] - 2026-07-02
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pages
-version: 0.7.2
+version: 0.7.3
 description: >
   Markdown-to-HTML rendering component for zylos. Renders .md files as beautifully
   styled web pages with code highlighting, dark/light theme, and table of contents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-pages",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-pages",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-pages",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Markdown-to-HTML rendering component for zylos — write .md, get beautiful web pages",
   "type": "module",
   "main": "src/index.js",

--- a/src/security/auth.js
+++ b/src/security/auth.js
@@ -596,7 +596,27 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
       return rejectAuthMisconfigured(req, res);
     }
 
-    // Share access session bypass for pages and raw HTML artifacts.
+    // Login session takes precedence over share-access cookies: an
+    // authenticated user always gets the authenticated (shell) view, even if
+    // the browser still carries a share-access cookie from a previously
+    // opened share link (#102).
+    if (validateSession(getSessionCookie(req))) {
+      res.locals.authenticated = true;
+      const origSetHeader = res.setHeader.bind(res);
+      res.setHeader = function(name, value) {
+        if (name.toLowerCase() === 'cache-control' && res.locals.authenticated) {
+          return origSetHeader('Cache-Control', 'no-store');
+        }
+        return origSetHeader(name, value);
+      };
+      res.setHeader('Cache-Control', 'no-store');
+      return next();
+    }
+
+    // Share access session bypass for pages and raw HTML artifacts —
+    // unauthenticated fallback only. Must keep matching /p/<uri>: share views
+    // carry <base href=".../p/<uri>">, so anchor/TOC navigation from a share
+    // lands on the logical route and relies on this bypass.
     if ((req.method === 'GET' || req.method === 'HEAD')
         && !req.path.startsWith('/api/')
         && !isAssetPath(req.path)
@@ -619,19 +639,6 @@ export function setupAuth(app, authConfig, sharingConfig = { enabled: true }) {
         acceptShareViewer(res, result);
         return next();
       }
-    }
-
-    if (validateSession(getSessionCookie(req))) {
-      res.locals.authenticated = true;
-      const origSetHeader = res.setHeader.bind(res);
-      res.setHeader = function(name, value) {
-        if (name.toLowerCase() === 'cache-control' && res.locals.authenticated) {
-          return origSetHeader('Cache-Control', 'no-store');
-        }
-        return origSetHeader(name, value);
-      };
-      res.setHeader('Cache-Control', 'no-store');
-      return next();
     }
 
     if (isAssetPath(req.path)) {

--- a/test/share-api.test.js
+++ b/test/share-api.test.js
@@ -63,6 +63,7 @@ function makeServer({ auth = false, authConfig = null, sharingEnabled = true, sh
     if (req.query.locals === '1') {
       return res.status(200).json({
         viewerType: res.locals.viewerType || null,
+        authenticated: res.locals.authenticated === true,
         shareCanWriteAttachments: res.locals.shareCanWriteAttachments === true,
       });
     }
@@ -398,6 +399,7 @@ test('auth middleware keeps short share cookies read-only', async () => {
     assert.equal(appCheck.status, 200);
     assert.deepEqual(await appCheck.json(), {
       viewerType: 'share',
+      authenticated: false,
       shareCanWriteAttachments: false,
     });
   } finally {
@@ -422,6 +424,106 @@ test('legacy long share token bypass is rejected while short links still work', 
     response = await fetch(`${origin}/s/${share.tokenId}`, { redirect: 'manual' });
     assert.equal(response.status, 200);
     assert.match(response.headers.get('set-cookie'), /__Host-share_access=/);
+  } finally {
+    server.close();
+  }
+});
+
+test('login session takes precedence over share-access cookie on /p/ routes (#102)', async () => {
+  const { server, origin } = await makeServer({ auth: true });
+  try {
+    const sessionCookie = await login(origin);
+    assert.match(sessionCookie, /__Host-zylos_pages_session=/);
+
+    const share = await createShareViaApi(origin, cookieHeader(sessionCookie), {
+      slug: 'p/docs/page',
+      duration: '24h',
+    });
+    const shareVisit = await fetch(share.url, { redirect: 'manual' });
+    assert.equal(shareVisit.status, 200);
+    const shareCookie = cookieHeader(shareVisit.headers.get('set-cookie'));
+    assert.match(shareCookie, /__Host-share_access=/);
+
+    // Both cookies present — the login session must win: authenticated view,
+    // never the shell-less share view.
+    const both = `${cookieHeader(sessionCookie)}; ${shareCookie}`;
+    const page = await fetch(`${origin}/p/docs/page?locals=1`, {
+      redirect: 'manual',
+      headers: { Cookie: both },
+    });
+    assert.equal(page.status, 200);
+    const locals = await page.json();
+    assert.equal(locals.authenticated, true);
+    assert.equal(locals.viewerType, null);
+  } finally {
+    server.close();
+  }
+});
+
+test('share-access cookie still grants the share view when unauthenticated (#102)', async () => {
+  const { server, origin } = await makeServer({ auth: true });
+  try {
+    const sessionCookie = await login(origin);
+    const share = await createShareViaApi(origin, cookieHeader(sessionCookie), {
+      slug: 'p/docs/page',
+      duration: '24h',
+    });
+    const shareVisit = await fetch(share.url, { redirect: 'manual' });
+    const shareCookie = cookieHeader(shareVisit.headers.get('set-cookie'));
+
+    // Share cookie only (no login session): the /p/ logical route must keep
+    // serving the share view — share pages carry <base href=".../p/<uri>">,
+    // so anchor/TOC navigation from a share lands here.
+    const page = await fetch(`${origin}/p/docs/page?locals=1`, {
+      redirect: 'manual',
+      headers: { Cookie: shareCookie },
+    });
+    assert.equal(page.status, 200);
+    const locals = await page.json();
+    assert.equal(locals.authenticated, false);
+    assert.equal(locals.viewerType, 'share');
+
+    // ...but any other page stays protected (URI pinning).
+    const other = await fetch(`${origin}/p/docs/other?locals=1`, {
+      redirect: 'manual',
+      headers: { Cookie: shareCookie },
+    });
+    assert.equal(other.status, 302);
+    assert.match(other.headers.get('location'), /^\/login\?next=/);
+  } finally {
+    server.close();
+  }
+});
+
+test('login and logout clear an existing share-access cookie (#102)', async () => {
+  const { server, origin } = await makeServer({ auth: true });
+  try {
+    const sessionCookie = await login(origin);
+    const share = await createShareViaApi(origin, cookieHeader(sessionCookie), {
+      slug: 'p/docs/page',
+      duration: '24h',
+    });
+    const shareVisit = await fetch(share.url, { redirect: 'manual' });
+    assert.match(shareVisit.headers.get('set-cookie'), /__Host-share_access=/);
+
+    // Logging in clears any lingering share-access cookie.
+    const relogin = await fetch(`${origin}/login`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ password: 'secret' }),
+    });
+    assert.equal(relogin.status, 302);
+    assert.match(relogin.headers.get('set-cookie'), /__Host-share_access=;.*Max-Age=0/);
+
+    // Logging out clears it too.
+    const logout = await fetch(`${origin}/logout`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { Origin: origin, Cookie: cookieHeader(sessionCookie) },
+    });
+    assert.equal(logout.status, 302);
+    assert.match(logout.headers.get('set-cookie'), /__Host-share_access=;.*Max-Age=0/);
   } finally {
     server.close();
   }


### PR DESCRIPTION
Fixes #102.

## Problem
The global auth middleware checked the `__Host-share_access` cookie **before** the login session. A logged-in user whose browser still carried a share cookie (from previously opening their own share link) was misclassified as a share visitor on `/pages/p/<uri>` — `viewerType=share`, shell-less raw view, `validateSession` never consulted.

## Fix
Reorder in `src/security/auth.js`: `validateSession` first; the share-access cookie is now the **unauthenticated fallback** only.

### Deliberate scope decision — share bypass keeps matching `/p/`
Issue #102 suggested optionally excluding `/p/` slugs from the share bypass. **Not done, on purpose**: share views inject `<base href=".../p/<uri>">" (`finalizeShareHtml`), so every anchor/TOC click by an unauthenticated share visitor navigates to `/p/<uri>#...` and depends on the share cookie passing there (also asserted by the pre-existing test *auth middleware allows short share URL cookies to access target page*). Excluding `/p/` would break share viewing. URI pinning already limits the cookie to the shared page only.

## Regression tests (new, in `test/share-api.test.js`)
1. **#102 scenario**: session + share cookie both present → `/p/<uri>` serves the authenticated view (`authenticated=true`, `viewerType=null`).
2. **Unauthenticated share fallback preserved**: share cookie alone → `/p/<uri>` still serves the share view; any *other* `/p/` page → 302 login (URI pinning).
3. **Cookie lifecycle**: both login and logout clear an existing share-access cookie (`Max-Age=0`).

The locals-reporting test stub now also reports `res.locals.authenticated`.

## Release
- Version bump 0.7.2 → 0.7.3 (package.json, package-lock ×2, SKILL.md frontmatter)
- CHANGELOG entry under [0.7.3]

## Tests
125/125 pass (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)